### PR TITLE
Fix metaverse nav fallback wrapper

### DIFF
--- a/components/metaverse-nav-fallback.tsx
+++ b/components/metaverse-nav-fallback.tsx
@@ -2,9 +2,11 @@
 
 export function MetaverseNavFallback() {
   return (
-    <div className="border-b border-border/40 backdrop-blur-sm h-20 w-full" />
-    <div className="w-full h-screen flex items-center justify-center bg-black text-primary">
-      Loading 3D Navigation...
-    </div>
+    <>
+      <div className="border-b border-border/40 backdrop-blur-sm h-20 w-full" />
+      <div className="w-full h-screen flex items-center justify-center bg-black text-primary">
+        Loading 3D Navigation...
+      </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- wrap the fallback nav component in a React fragment

## Testing
- `pnpm build` *(fails: Unexpected token `div` in app/projects/[id]/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6844f6478230832baa8d664e5004226d