### PR TITLE
Add personalized project filter

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import Link from "next/link"
 import { Terminal } from "@/components/terminal"
 import { ProjectCard } from "@/components/project-card"
+import { ProjectFilter } from "@/components/project-filter"
 import { BlogCard } from "@/components/blog-card"
 import { ArrowRight } from "lucide-react"
 import { HeroBackground } from "@/components/hero-background"
@@ -93,11 +94,7 @@ export default function Home() {
           </Link>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {featuredProjects.map((project) => (
-            <ProjectCard key={project.id} {...project} />
-          ))}
-        </div>
+        <ProjectFilter projects={featuredProjects} />
       </section>
 
       <section>

--- a/components/project-filter.tsx
+++ b/components/project-filter.tsx
@@ -36,11 +36,13 @@ export function ProjectFilter({ projects }: ProjectFilterProps) {
     const matches = projects.filter((p) =>
       p.technologies.some((tag) => tag.toLowerCase().includes(text))
     )
-    const others = projects.filter(
-      (p) => !p.technologies.some((tag) => tag.toLowerCase().includes(text))
-    )
-    setDisplay([...matches, ...others])
-    setPersonalized(true)
+    if (matches.length > 0) {
+      setDisplay(matches)
+      setPersonalized(true)
+    } else {
+      setDisplay(projects)
+      setPersonalized(false)
+    }
   }
 
   const handleReset = () => {

--- a/components/project-filter.tsx
+++ b/components/project-filter.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { ProjectCard } from "@/components/project-card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+export interface Project {
+  id: string
+  title: string
+  description: string
+  image: string
+  technologies: string[]
+}
+
+interface ProjectFilterProps {
+  projects: Project[]
+}
+
+export function ProjectFilter({ projects }: ProjectFilterProps) {
+  const [query, setQuery] = useState("")
+  const [personalized, setPersonalized] = useState(false)
+  const [display, setDisplay] = useState<Project[]>(projects)
+
+  useEffect(() => {
+    setDisplay(projects)
+  }, [projects])
+
+  const handlePersonalize = () => {
+    const text = query.trim().toLowerCase()
+    if (!text) {
+      setDisplay(projects)
+      setPersonalized(false)
+      return
+    }
+    const matches = projects.filter((p) =>
+      p.technologies.some((tag) => tag.toLowerCase().includes(text))
+    )
+    const others = projects.filter(
+      (p) => !p.technologies.some((tag) => tag.toLowerCase().includes(text))
+    )
+    setDisplay([...matches, ...others])
+    setPersonalized(true)
+  }
+
+  const handleReset = () => {
+    setQuery("")
+    setDisplay(projects)
+    setPersonalized(false)
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col sm:flex-row gap-2">
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Enter a keyword"
+          className="flex-1"
+        />
+        <Button onClick={handlePersonalize}>Personalize</Button>
+        {personalized && (
+          <Button variant="secondary" onClick={handleReset}>
+            Reset
+          </Button>
+        )}
+      </div>
+
+      {personalized && (
+        <h3 className="text-xl font-bold">
+          Projects aligned with “{query.trim()}”:
+        </h3>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {display.map((project) => (
+          <ProjectCard key={project.id} {...project} />
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- enable customization of featured projects by keywords
- create `ProjectFilter` component to manage filtering
- integrate filter on the homepage

## Testing
- `pnpm install --ignore-scripts`
- `pnpm lint` *(fails: ESLint not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68622a20b7c0832b82ee422ab352f6c6