### PR TITLE
Simplify project filtering

### DIFF
--- a/components/project-filter.tsx
+++ b/components/project-filter.tsx
@@ -34,16 +34,12 @@ export function ProjectFilter({ projects }: ProjectFilterProps) {
       return
     }
 
-    const matches: Project[] = []
-    for (const project of projects) {
-      if (
-        project.technologies.some((tag) =>
-          tag.toLowerCase().includes(text)
-        )
-      ) {
-        matches.push(project)
-      }
-    }
+    const matches = projects.filter(
+      (p) =>
+        p.title.toLowerCase().includes(text) ||
+        p.description.toLowerCase().includes(text) ||
+        p.technologies.some((tag) => tag.toLowerCase().includes(text))
+    )
 
     if (matches.length > 0) {
       setDisplay(matches)


### PR DESCRIPTION
## Summary
- streamline ProjectFilter logic by using `projects.filter`
- match against project title and description in addition to technologies

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862326da178832b9812ccff78fc8691