### PR TITLE
Add shared Project interface

### DIFF
--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -1,13 +1,8 @@
 import Image from "next/image"
 import Link from "next/link"
+import type { Project } from "@/types/project"
 
-interface ProjectCardProps {
-  id: string
-  title: string
-  description: string
-  image: string
-  technologies: string[]
-}
+type ProjectCardProps = Project
 
 export function ProjectCard({ id, title, description, image, technologies }: ProjectCardProps) {
   return (

--- a/types/project.ts
+++ b/types/project.ts
@@ -1,0 +1,7 @@
+export interface Project {
+  id: string
+  title: string
+  description: string
+  image: string
+  technologies: string[]
+}


### PR DESCRIPTION
## Summary
- add a reusable `Project` interface
- update `ProjectCard` props to use it

## Testing
- `pnpm lint` *(fails: interactive eslint prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68622ea5f914832ba8ea4e99358fb6ad