### PR TITLE
Wrap project filter inputs in form

### DIFF
--- a/components/project-filter.tsx
+++ b/components/project-filter.tsx
@@ -58,20 +58,26 @@ export function ProjectFilter({ projects }: ProjectFilterProps) {
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-col sm:flex-row gap-2">
+      <form
+        className="flex flex-col sm:flex-row gap-2"
+        onSubmit={(e) => {
+          e.preventDefault()
+          handlePersonalize()
+        }}
+      >
         <Input
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Enter a keyword"
           className="flex-1"
         />
-        <Button onClick={handlePersonalize}>Personalize</Button>
+        <Button type="submit">Personalize</Button>
         {personalized && (
-          <Button variant="secondary" onClick={handleReset}>
+          <Button type="button" variant="secondary" onClick={handleReset}>
             Reset
           </Button>
         )}
-      </div>
+      </form>
 
       {personalized && (
         <h3 className="text-xl font-bold">


### PR DESCRIPTION
## Summary
- wrap personalization fields in a form
- submit form to trigger personalization logic and prevent page reload

## Testing
- `pnpm install`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68623e1b301c832b964c87cdd527f34b