### PR TITLE
Update README with local dev URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ pnpm install
 pnpm dev
 ```
 
-The site will be available at [https://mikechaves.io](https://mikechaves.io).
+The local site will be running at [http://localhost:3000](http://localhost:3000).
+
+The production site is available at [https://mikechaves.io](https://mikechaves.io).
 
 ### Environment Variables
 


### PR DESCRIPTION
## Summary
- document that `pnpm dev` starts the site at `http://localhost:3000`
- keep production URL link

## Testing
- `pnpm lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68624585cb6c832bb6a8096812b4c624