### PR TITLE
Enable full project personalization

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,6 +40,81 @@ export default function Home() {
     },
   ]
 
+  const allProjects = [
+    {
+      id: "geovoice",
+      title: "GeoVoice",
+      description:
+        "A platform created to streamline geospatial data analysis and stakeholder feedback, primarily for large-scale infrastructure and environmental planning projects. The result is a more transparent and efficient way to collaborate.",
+      image: "/projects/geovoice/main-image.png?height=400&width=600",
+      technologies: ["Geospatial Mapping", "UX/UI Design", "Data Visualization"],
+    },
+    {
+      id: "transcribe",
+      title: "Transcribe",
+      description:
+        "Improved communication in Starbucks stores with real-time speech-to-text transcription, enhancing inclusivity and operational efficiency.",
+      image: "/projects/transcribe/main-image.png?height=400&width=600",
+      technologies: ["React.js", "UX/UI Design", "Speech-to-Text API"],
+    },
+    {
+      id: "gaia",
+      title: "Gaia",
+      description:
+        "Transformed data analytics into practical, experiential contexts through spatial computing for Starbucks, enhancing store operations and training.",
+      image: "/projects/gaia/main-image.png?height=400&width=600",
+      technologies: ["UX Design", "AR/VR", "Unity3D"],
+    },
+    {
+      id: "apt-plus",
+      title: "APT+",
+      description:
+        "Streamlined manufacturing workflows for Ford by improving time studies, saving approximately $1M per plant annually.",
+      image: "/projects/apt-plus/main-image.png?height=400&width=600",
+      technologies: ["UX/UI Design", "Data Visualization", "Process Optimization"],
+    },
+    {
+      id: "speakeasy",
+      title: "SpeakEasy",
+      description:
+        "Reimagining XR for a more inclusive future with voice-driven AI interfaces for users with physical challenges.",
+      image: "/projects/speakeasy/thesis-defense.jpg?height=400&width=600",
+      technologies: ["Voice-Driven AI", "XR Accessibility", "Inclusive Design"],
+    },
+    {
+      id: "sound-escape-vr",
+      title: "Sound Escape VR",
+      description:
+        "An immersive VR music creation and visualization experience with a retro 80s synthwave aesthetic, allowing users to compose music and see the environment transform in response.",
+      image: "/projects/soundescape/main-image.jpg?height=400&width=600",
+      technologies: ["Unity3D", "C#", "VR Development", "Audio Visualization"],
+    },
+    {
+      id: "material-explorer",
+      title: "Material Explorer",
+      description:
+        "An interactive web application for creating, customizing, and visualizing 3D materials in real-time using Three.js and React Three Fiber.",
+      image: "/projects/material-explorer/main-image.png?height=400&width=600",
+      technologies: ["TypeScript", "React", "Three.js", "WebGL"],
+    },
+    {
+      id: "portals",
+      title: "Portals",
+      description:
+        "An immersive AR experience for Snap Spectacles designed to bring music, culture, and climate awareness to life through interactive and accessible features.",
+      image: "/projects/portals/main-image.png?height=400&width=600",
+      technologies: ["AR", "Snap Spectacles", "Spatial Audio", "Voice UI", "Accessibility"],
+    },
+    {
+      id: "ai-energy-consumption",
+      title: "AI Energy Consumption",
+      description:
+        "An interactive 3D data visualization showcasing the global impact of AI's energy consumption and CO2 emissions across different countries and regions.",
+      image: "/projects/ai-energy-consumption/main-image.png?height=400&width=600",
+      technologies: ["A-Frame", "D3.js", "3D Visualization", "Data Storytelling"],
+    },
+  ]
+
   const latestPosts = [
     {
       id: "voice-first-xr",
@@ -94,7 +169,7 @@ export default function Home() {
           </Link>
         </div>
 
-        <ProjectFilter projects={featuredProjects} />
+        <ProjectFilter featured={featuredProjects} projects={allProjects} />
       </section>
 
       <section>

--- a/components/project-filter.tsx
+++ b/components/project-filter.tsx
@@ -14,22 +14,23 @@ export interface Project {
 }
 
 interface ProjectFilterProps {
+  featured: Project[]
   projects: Project[]
 }
 
-export function ProjectFilter({ projects }: ProjectFilterProps) {
+export function ProjectFilter({ featured, projects }: ProjectFilterProps) {
   const [query, setQuery] = useState("")
   const [personalized, setPersonalized] = useState(false)
-  const [display, setDisplay] = useState<Project[]>(projects)
+  const [display, setDisplay] = useState<Project[]>(featured)
 
   useEffect(() => {
-    setDisplay(projects)
-  }, [projects])
+    setDisplay(featured)
+  }, [featured])
 
   const handlePersonalize = () => {
     const text = query.trim().toLowerCase()
     if (!text) {
-      setDisplay(projects)
+      setDisplay(featured)
       setPersonalized(false)
       return
     }
@@ -40,19 +41,27 @@ export function ProjectFilter({ projects }: ProjectFilterProps) {
         (p.description || "").toLowerCase().includes(text) ||
         (p.technologies || []).some((tag) => (tag || "").toLowerCase().includes(text))
     )
+    const nonMatches = projects.filter(
+      (p) =>
+        !(
+          (p.title || "").toLowerCase().includes(text) ||
+          (p.description || "").toLowerCase().includes(text) ||
+          (p.technologies || []).some((tag) => (tag || "").toLowerCase().includes(text))
+        )
+    )
 
     if (matches.length > 0) {
-      setDisplay(matches)
+      setDisplay([...matches, ...nonMatches])
       setPersonalized(true)
     } else {
-      setDisplay(projects)
+      setDisplay(featured)
       setPersonalized(false)
     }
   }
 
   const handleReset = () => {
     setQuery("")
-    setDisplay(projects)
+    setDisplay(featured)
     setPersonalized(false)
   }
 

--- a/components/project-filter.tsx
+++ b/components/project-filter.tsx
@@ -41,17 +41,9 @@ export function ProjectFilter({ featured, projects }: ProjectFilterProps) {
         (p.description || "").toLowerCase().includes(text) ||
         (p.technologies || []).some((tag) => (tag || "").toLowerCase().includes(text))
     )
-    const nonMatches = projects.filter(
-      (p) =>
-        !(
-          (p.title || "").toLowerCase().includes(text) ||
-          (p.description || "").toLowerCase().includes(text) ||
-          (p.technologies || []).some((tag) => (tag || "").toLowerCase().includes(text))
-        )
-    )
 
     if (matches.length > 0) {
-      setDisplay([...matches, ...nonMatches])
+      setDisplay(matches)
       setPersonalized(true)
     } else {
       setDisplay(featured)


### PR DESCRIPTION
## Summary
- personalize project filtering across all projects, keeping featured projects as the default view
- list the entire project catalog on the homepage for personalization

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6865eef82280832b852e5a6fa02baf57