### PR TITLE
Centralize blog post data

### DIFF
--- a/app/blog/ai-becomes-user/page.tsx
+++ b/app/blog/ai-becomes-user/page.tsx
@@ -2,11 +2,14 @@ import Link from "next/link"
 import Image from "next/image"
 import { ArrowLeft } from "lucide-react"
 import { posts } from "@/lib/posts"
-import type { Post } from "@/types/post"
+import { notFound } from "next/navigation"
 
-const post = posts.find((p) => p.id === "ai-becomes-user") as Post
+const post = posts.find((p) => p.id === "ai-becomes-user")
 
 export default function AIBecomesUserPage() {
+  if (!post) {
+    notFound()
+  }
   return (
     <div className="max-w-3xl mx-auto pt-8">
       <Link href="/blog" className="inline-flex items-center gap-2 text-primary hover:underline mb-8">
@@ -15,7 +18,7 @@ export default function AIBecomesUserPage() {
 
       <div className="relative h-64 rounded-md overflow-hidden mb-8 bg-gradient-to-r from-blue-900 via-purple-900 to-indigo-900">
         <Image
-          src={post.image.replace("width=600", "width=1200").replace("height=400", "height=600")}
+          src={post.image.replace(/width=\d+/, "width=1200").replace(/height=\d+/, "height=600")}
           alt={post.title}
           fill
           className="object-cover mix-blend-overlay opacity-70"

--- a/app/blog/ai-becomes-user/page.tsx
+++ b/app/blog/ai-becomes-user/page.tsx
@@ -1,6 +1,10 @@
 import Link from "next/link"
 import Image from "next/image"
 import { ArrowLeft } from "lucide-react"
+import { posts } from "@/lib/posts"
+import type { Post } from "@/types/post"
+
+const post = posts.find((p) => p.id === "ai-becomes-user") as Post
 
 export default function AIBecomesUserPage() {
   return (
@@ -11,8 +15,8 @@ export default function AIBecomesUserPage() {
 
       <div className="relative h-64 rounded-md overflow-hidden mb-8 bg-gradient-to-r from-blue-900 via-purple-900 to-indigo-900">
         <Image
-          src={`/api/placeholder?width=1200&height=600&text=${encodeURIComponent('When AI Becomes the User')}`}
-          alt="When AI Becomes the User"
+          src={post.image.replace("width=600", "width=1200").replace("height=400", "height=600")}
+          alt={post.title}
           fill
           className="object-cover mix-blend-overlay opacity-70"
         />
@@ -20,12 +24,12 @@ export default function AIBecomesUserPage() {
 
       <div className="mb-8">
         <div className="inline-block px-3 py-1 mb-3 text-xs border border-zinc-700 rounded-full text-zinc-400">
-          Bootcamp
+          {post.publication}
         </div>
-        <h1 className="text-3xl font-bold mb-4">When AI Becomes the User: Redefining UX/UI for the Future</h1>
+        <h1 className="text-3xl font-bold mb-4">{post.title}</h1>
         <div className="flex items-center gap-4 text-sm text-zinc-400">
-          <div>Jan 28, 2025</div>
-          <div>7 min read</div>
+          <div>{post.date}</div>
+          <div>{post.readingTime}</div>
         </div>
       </div>
 
@@ -34,7 +38,7 @@ export default function AIBecomesUserPage() {
           This article is available on Medium. Click the button below to read the full article.
         </p>
         <a
-          href="https://medium.com/design-bootcamp/when-ai-becomes-the-user-redefining-ux-ui-for-the-future-ac6bbc6eb084"
+          href={post.url}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex items-center gap-2 bg-primary text-black px-4 py-2 rounded-md hover:bg-primary/90 transition-colors"

--- a/app/blog/embracing-ambiguity/page.tsx
+++ b/app/blog/embracing-ambiguity/page.tsx
@@ -2,11 +2,14 @@ import Link from "next/link"
 import Image from "next/image"
 import { ArrowLeft } from "lucide-react"
 import { posts } from "@/lib/posts"
-import type { Post } from "@/types/post"
+import { notFound } from "next/navigation"
 
-const post = posts.find((p) => p.id === "embracing-ambiguity") as Post
+const post = posts.find((p) => p.id === "embracing-ambiguity")
 
 export default function EmbracingAmbiguityPage() {
+  if (!post) {
+    notFound()
+  }
   return (
     <div className="max-w-3xl mx-auto pt-8">
       <Link href="/blog" className="inline-flex items-center gap-2 text-primary hover:underline mb-8">
@@ -15,7 +18,7 @@ export default function EmbracingAmbiguityPage() {
 
       <div className="relative h-64 rounded-md overflow-hidden mb-8 bg-gradient-to-r from-purple-900 via-pink-700 to-blue-900">
         <Image
-          src={post.image.replace("width=600", "width=1200").replace("height=400", "height=600")}
+          src={post.image.replace(/width=\d+/, "width=1200").replace(/height=\d+/, "height=600")}
           alt={post.title}
           fill
           className="object-cover mix-blend-overlay opacity-70"

--- a/app/blog/embracing-ambiguity/page.tsx
+++ b/app/blog/embracing-ambiguity/page.tsx
@@ -1,6 +1,10 @@
 import Link from "next/link"
 import Image from "next/image"
 import { ArrowLeft } from "lucide-react"
+import { posts } from "@/lib/posts"
+import type { Post } from "@/types/post"
+
+const post = posts.find((p) => p.id === "embracing-ambiguity") as Post
 
 export default function EmbracingAmbiguityPage() {
   return (
@@ -11,8 +15,8 @@ export default function EmbracingAmbiguityPage() {
 
       <div className="relative h-64 rounded-md overflow-hidden mb-8 bg-gradient-to-r from-purple-900 via-pink-700 to-blue-900">
         <Image
-          src={`/api/placeholder?width=1200&height=600&text=${encodeURIComponent('Embracing Ambiguity')}`}
-          alt="Embracing Ambiguity"
+          src={post.image.replace("width=600", "width=1200").replace("height=400", "height=600")}
+          alt={post.title}
           fill
           className="object-cover mix-blend-overlay opacity-70"
         />
@@ -20,14 +24,12 @@ export default function EmbracingAmbiguityPage() {
 
       <div className="mb-8">
         <div className="inline-block px-3 py-1 mb-3 text-xs border border-zinc-700 rounded-full text-zinc-400">
-          Bootcamp
+          {post.publication}
         </div>
-        <h1 className="text-3xl font-bold mb-4">
-          Embracing Ambiguity: Finding Clarity in the Chaos of Modern Technology
-        </h1>
+        <h1 className="text-3xl font-bold mb-4">{post.title}</h1>
         <div className="flex items-center gap-4 text-sm text-zinc-400">
-          <div>Feb 12, 2025</div>
-          <div>6 min read</div>
+          <div>{post.date}</div>
+          <div>{post.readingTime}</div>
         </div>
       </div>
 
@@ -36,7 +38,7 @@ export default function EmbracingAmbiguityPage() {
           This article is available on Medium. Click the button below to read the full article.
         </p>
         <a
-          href="https://medium.com/design-bootcamp/embracing-ambiguity-finding-clarity-in-the-chaos-of-modern-technology-415e5834e150"
+          href={post.url}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex items-center gap-2 bg-primary text-black px-4 py-2 rounded-md hover:bg-primary/90 transition-colors"

--- a/app/blog/extended-pausabilities/page.tsx
+++ b/app/blog/extended-pausabilities/page.tsx
@@ -1,6 +1,10 @@
 import Link from "next/link"
 import Image from "next/image"
 import { ArrowLeft } from "lucide-react"
+import { posts } from "@/lib/posts"
+import type { Post } from "@/types/post"
+
+const post = posts.find((p) => p.id === "extended-pausabilities") as Post
 
 export default function ExtendedPausabilitiesPage() {
   return (
@@ -11,8 +15,8 @@ export default function ExtendedPausabilitiesPage() {
 
       <div className="relative h-64 rounded-md overflow-hidden mb-8 bg-gradient-to-r from-green-900 via-teal-900 to-cyan-900">
         <Image
-          src={`/api/placeholder?width=1200&height=600&text=${encodeURIComponent('Extended Pausabilities')}`}
-          alt="Extended Pausabilities"
+          src={post.image.replace("width=600", "width=1200").replace("height=400", "height=600")}
+          alt={post.title}
           fill
           className="object-cover mix-blend-overlay opacity-70"
         />
@@ -20,12 +24,12 @@ export default function ExtendedPausabilitiesPage() {
 
       <div className="mb-8">
         <div className="inline-block px-3 py-1 mb-3 text-xs border border-zinc-700 rounded-full text-zinc-400">
-          Bootcamp
+          {post.publication}
         </div>
-        <h1 className="text-3xl font-bold mb-4">Extended Pausabilities: Navigating XR with Accessibility in Mind</h1>
+        <h1 className="text-3xl font-bold mb-4">{post.title}</h1>
         <div className="flex items-center gap-4 text-sm text-zinc-400">
-          <div>Dec 15, 2024</div>
-          <div>8 min read</div>
+          <div>{post.date}</div>
+          <div>{post.readingTime}</div>
         </div>
       </div>
 
@@ -34,7 +38,7 @@ export default function ExtendedPausabilitiesPage() {
           This article is available on Medium. Click the button below to read the full article.
         </p>
         <a
-          href="https://medium.com/design-bootcamp/extended-pausabilities-navigating-xr-with-accessibility-in-mind-1fa35fb4d590"
+          href={post.url}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex items-center gap-2 bg-primary text-black px-4 py-2 rounded-md hover:bg-primary/90 transition-colors"

--- a/app/blog/extended-pausabilities/page.tsx
+++ b/app/blog/extended-pausabilities/page.tsx
@@ -2,11 +2,14 @@ import Link from "next/link"
 import Image from "next/image"
 import { ArrowLeft } from "lucide-react"
 import { posts } from "@/lib/posts"
-import type { Post } from "@/types/post"
+import { notFound } from "next/navigation"
 
-const post = posts.find((p) => p.id === "extended-pausabilities") as Post
+const post = posts.find((p) => p.id === "extended-pausabilities")
 
 export default function ExtendedPausabilitiesPage() {
+  if (!post) {
+    notFound()
+  }
   return (
     <div className="max-w-3xl mx-auto pt-8">
       <Link href="/blog" className="inline-flex items-center gap-2 text-primary hover:underline mb-8">
@@ -15,7 +18,7 @@ export default function ExtendedPausabilitiesPage() {
 
       <div className="relative h-64 rounded-md overflow-hidden mb-8 bg-gradient-to-r from-green-900 via-teal-900 to-cyan-900">
         <Image
-          src={post.image.replace("width=600", "width=1200").replace("height=400", "height=600")}
+          src={post.image.replace(/width=\d+/, "width=1200").replace(/height=\d+/, "height=600")}
           alt={post.title}
           fill
           className="object-cover mix-blend-overlay opacity-70"

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,65 +1,7 @@
 import { BlogCard } from "@/components/blog-card"
+import { posts } from "@/lib/posts"
 
 export default function BlogPage() {
-  const posts = [
-    {
-      id: "voice-first-xr",
-      title: "Voice-First XR: Five Lessons from the Front Lines of Inclusive Design",
-      excerpt: "Key takeaways for crafting accessible voice interfaces in spatial computing.",
-      date: "Jun 18, 2025",
-      readingTime: "5 min read",
-      url: "https://medium.com/@mikejchaves/voice-first-xr-five-lessons-from-the-front-lines-of-inclusive-design-e58dacf49c54",
-      image: `/api/placeholder?width=600&height=400&text=${encodeURIComponent('Voice-First XR')}`,
-      publication: "Bootcamp",
-      featured: true,
-    },
-    {
-      id: "embracing-ambiguity",
-      title: "Embracing Ambiguity: Finding Clarity in the Chaos of Modern Technology",
-      excerpt:
-        "Navigating the complex landscape of emerging technologies and finding meaningful solutions amid uncertainty.",
-      date: "Feb 12, 2025",
-      readingTime: "6 min read",
-      url: "https://medium.com/design-bootcamp/embracing-ambiguity-finding-clarity-in-the-chaos-of-modern-technology-415e5834e150",
-      image: `/api/placeholder?width=600&height=400&text=${encodeURIComponent('Embracing Ambiguity')}`,
-      publication: "Bootcamp",
-      featured: true,
-    },
-    {
-      id: "ai-becomes-user",
-      title: "When AI Becomes the User: Redefining UX/UI for the Future",
-      excerpt: "Exploring how AI as a user changes our approach to interface design and user experience strategies.",
-      date: "Jan 28, 2025",
-      readingTime: "7 min read",
-      url: "https://medium.com/design-bootcamp/when-ai-becomes-the-user-redefining-ux-ui-for-the-future-ac6bbc6eb084",
-      image: `/api/placeholder?width=600&height=400&text=${encodeURIComponent('When AI Becomes the User')}`,
-      publication: "Bootcamp",
-      featured: false,
-    },
-    {
-      id: "extended-pausabilities",
-      title: "Extended Pausabilities: Navigating XR with Accessibility in Mind",
-      excerpt: "How to design inclusive extended reality experiences that work for users of all abilities.",
-      date: "Dec 15, 2024",
-      readingTime: "8 min read",
-      url: "https://medium.com/design-bootcamp/extended-pausabilities-navigating-xr-with-accessibility-in-mind-1fa35fb4d590",
-      image: `/api/placeholder?width=600&height=400&text=${encodeURIComponent('Extended Pausabilities')}`,
-      publication: "Bootcamp",
-      featured: false,
-    },
-    {
-      id: "redefining-reality",
-      title: "Redefining Reality: The Future of Design in XR",
-      excerpt:
-        "How extended reality is transforming design principles and creating new possibilities for immersive experiences.",
-      date: "Nov 30, 2024",
-      readingTime: "6 min read",
-      url: "https://medium.com/design-bootcamp/redefining-reality-the-future-of-design-in-xr-a5e053e255a8",
-      image: `/api/placeholder?width=600&height=400&text=${encodeURIComponent('Redefining Reality')}`,
-      publication: "Bootcamp",
-      featured: false,
-    },
-  ]
 
   return (
     <div className="space-y-8 pt-8">

--- a/app/blog/redefining-reality/page.tsx
+++ b/app/blog/redefining-reality/page.tsx
@@ -2,11 +2,14 @@ import Link from "next/link"
 import Image from "next/image"
 import { ArrowLeft } from "lucide-react"
 import { posts } from "@/lib/posts"
-import type { Post } from "@/types/post"
+import { notFound } from "next/navigation"
 
-const post = posts.find((p) => p.id === "redefining-reality") as Post
+const post = posts.find((p) => p.id === "redefining-reality")
 
 export default function RedefiningRealityPage() {
+  if (!post) {
+    notFound()
+  }
   return (
     <div className="max-w-3xl mx-auto pt-8">
       <Link href="/blog" className="inline-flex items-center gap-2 text-primary hover:underline mb-8">
@@ -15,7 +18,7 @@ export default function RedefiningRealityPage() {
 
       <div className="relative h-64 rounded-md overflow-hidden mb-8 bg-gradient-to-r from-orange-900 via-red-900 to-pink-900">
         <Image
-          src={post.image.replace("width=600", "width=1200").replace("height=400", "height=600")}
+          src={post.image.replace(/width=\d+/, "width=1200").replace(/height=\d+/, "height=600")}
           alt={post.title}
           fill
           className="object-cover mix-blend-overlay opacity-70"

--- a/app/blog/redefining-reality/page.tsx
+++ b/app/blog/redefining-reality/page.tsx
@@ -1,6 +1,10 @@
 import Link from "next/link"
 import Image from "next/image"
 import { ArrowLeft } from "lucide-react"
+import { posts } from "@/lib/posts"
+import type { Post } from "@/types/post"
+
+const post = posts.find((p) => p.id === "redefining-reality") as Post
 
 export default function RedefiningRealityPage() {
   return (
@@ -11,8 +15,8 @@ export default function RedefiningRealityPage() {
 
       <div className="relative h-64 rounded-md overflow-hidden mb-8 bg-gradient-to-r from-orange-900 via-red-900 to-pink-900">
         <Image
-          src={`/api/placeholder?width=1200&height=600&text=${encodeURIComponent('Redefining Reality')}`}
-          alt="Redefining Reality"
+          src={post.image.replace("width=600", "width=1200").replace("height=400", "height=600")}
+          alt={post.title}
           fill
           className="object-cover mix-blend-overlay opacity-70"
         />
@@ -20,12 +24,12 @@ export default function RedefiningRealityPage() {
 
       <div className="mb-8">
         <div className="inline-block px-3 py-1 mb-3 text-xs border border-zinc-700 rounded-full text-zinc-400">
-          Bootcamp
+          {post.publication}
         </div>
-        <h1 className="text-3xl font-bold mb-4">Redefining Reality: The Future of Design in XR</h1>
+        <h1 className="text-3xl font-bold mb-4">{post.title}</h1>
         <div className="flex items-center gap-4 text-sm text-zinc-400">
-          <div>Nov 30, 2024</div>
-          <div>6 min read</div>
+          <div>{post.date}</div>
+          <div>{post.readingTime}</div>
         </div>
       </div>
 
@@ -34,7 +38,7 @@ export default function RedefiningRealityPage() {
           This article is available on Medium. Click the button below to read the full article.
         </p>
         <a
-          href="https://medium.com/design-bootcamp/redefining-reality-the-future-of-design-in-xr-a5e053e255a8"
+          href={post.url}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex items-center gap-2 bg-primary text-black px-4 py-2 rounded-md hover:bg-primary/90 transition-colors"

--- a/app/blog/voice-first-xr/page.tsx
+++ b/app/blog/voice-first-xr/page.tsx
@@ -1,17 +1,12 @@
 import Link from "next/link"
 import Image from "next/image"
 import { ArrowLeft } from "lucide-react"
+import { posts } from "@/lib/posts"
+import type { Post } from "@/types/post"
+
+const post = posts.find((p) => p.id === "voice-first-xr") as Post
 
 export default function VoiceFirstXRPage() {
-  const postDetails = {
-    title: "Voice-First XR: Five Lessons from the Front Lines of Inclusive Design",
-    date: "Jun 18, 2025",
-    readingTime: "5 min read",
-    publication: "Bootcamp",
-    mediumUrl:
-      "https://medium.com/@mikejchaves/voice-first-xr-five-lessons-from-the-front-lines-of-inclusive-design-e58dacf49c54",
-    imageText: "Voice-First XR",
-  }
   return (
     <div className="max-w-3xl mx-auto pt-8">
       <Link href="/blog" className="inline-flex items-center gap-2 text-primary hover:underline mb-8">
@@ -20,8 +15,8 @@ export default function VoiceFirstXRPage() {
 
       <div className="relative h-64 rounded-md overflow-hidden mb-8 bg-gradient-to-r from-indigo-900 via-purple-900 to-blue-900">
         <Image
-          src={`/api/placeholder?width=1200&height=600&text=${encodeURIComponent(postDetails.imageText)}`}
-          alt={postDetails.title}
+          src={post.image.replace("width=600", "width=1200").replace("height=400", "height=600")}
+          alt={post.title}
           fill
           className="object-cover mix-blend-overlay opacity-70"
         />
@@ -29,12 +24,12 @@ export default function VoiceFirstXRPage() {
 
       <div className="mb-8">
         <div className="inline-block px-3 py-1 mb-3 text-xs border border-zinc-700 rounded-full text-zinc-400">
-          {postDetails.publication}
+          {post.publication}
         </div>
-        <h1 className="text-3xl font-bold mb-4">{postDetails.title}</h1>
+        <h1 className="text-3xl font-bold mb-4">{post.title}</h1>
         <div className="flex items-center gap-4 text-sm text-zinc-400">
-          <div>{postDetails.date}</div>
-          <div>{postDetails.readingTime}</div>
+          <div>{post.date}</div>
+          <div>{post.readingTime}</div>
         </div>
       </div>
 
@@ -43,7 +38,7 @@ export default function VoiceFirstXRPage() {
           This article is available on Medium. Click the button below to read the full article.
         </p>
         <a
-          href={postDetails.mediumUrl}
+          href={post.url}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex items-center gap-2 bg-primary text-black px-4 py-2 rounded-md hover:bg-primary/90 transition-colors"

--- a/app/blog/voice-first-xr/page.tsx
+++ b/app/blog/voice-first-xr/page.tsx
@@ -2,11 +2,14 @@ import Link from "next/link"
 import Image from "next/image"
 import { ArrowLeft } from "lucide-react"
 import { posts } from "@/lib/posts"
-import type { Post } from "@/types/post"
+import { notFound } from "next/navigation"
 
-const post = posts.find((p) => p.id === "voice-first-xr") as Post
+const post = posts.find((p) => p.id === "voice-first-xr")
 
 export default function VoiceFirstXRPage() {
+  if (!post) {
+    notFound()
+  }
   return (
     <div className="max-w-3xl mx-auto pt-8">
       <Link href="/blog" className="inline-flex items-center gap-2 text-primary hover:underline mb-8">
@@ -15,7 +18,7 @@ export default function VoiceFirstXRPage() {
 
       <div className="relative h-64 rounded-md overflow-hidden mb-8 bg-gradient-to-r from-indigo-900 via-purple-900 to-blue-900">
         <Image
-          src={post.image.replace("width=600", "width=1200").replace("height=400", "height=600")}
+          src={post.image.replace(/width=\d+/, "width=1200").replace(/height=\d+/, "height=600")}
           alt={post.title}
           fill
           className="object-cover mix-blend-overlay opacity-70"

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,0 +1,61 @@
+import type { Post } from "@/types/post"
+
+export const posts: Post[] = [
+  {
+    id: "voice-first-xr",
+    title: "Voice-First XR: Five Lessons from the Front Lines of Inclusive Design",
+    excerpt: "Key takeaways for crafting accessible voice interfaces in spatial computing.",
+    date: "Jun 18, 2025",
+    readingTime: "5 min read",
+    url: "https://medium.com/@mikejchaves/voice-first-xr-five-lessons-from-the-front-lines-of-inclusive-design-e58dacf49c54",
+    image: `/api/placeholder?width=600&height=400&text=${encodeURIComponent('Voice-First XR')}`,
+    publication: "Bootcamp",
+    featured: true,
+  },
+  {
+    id: "embracing-ambiguity",
+    title: "Embracing Ambiguity: Finding Clarity in the Chaos of Modern Technology",
+    excerpt:
+      "Navigating the complex landscape of emerging technologies and finding meaningful solutions amid uncertainty.",
+    date: "Feb 12, 2025",
+    readingTime: "6 min read",
+    url: "https://medium.com/design-bootcamp/embracing-ambiguity-finding-clarity-in-the-chaos-of-modern-technology-415e5834e150",
+    image: `/api/placeholder?width=600&height=400&text=${encodeURIComponent('Embracing Ambiguity')}`,
+    publication: "Bootcamp",
+    featured: true,
+  },
+  {
+    id: "ai-becomes-user",
+    title: "When AI Becomes the User: Redefining UX/UI for the Future",
+    excerpt: "Exploring how AI as a user changes our approach to interface design and user experience strategies.",
+    date: "Jan 28, 2025",
+    readingTime: "7 min read",
+    url: "https://medium.com/design-bootcamp/when-ai-becomes-the-user-redefining-ux-ui-for-the-future-ac6bbc6eb084",
+    image: `/api/placeholder?width=600&height=400&text=${encodeURIComponent('When AI Becomes the User')}`,
+    publication: "Bootcamp",
+    featured: false,
+  },
+  {
+    id: "extended-pausabilities",
+    title: "Extended Pausabilities: Navigating XR with Accessibility in Mind",
+    excerpt: "How to design inclusive extended reality experiences that work for users of all abilities.",
+    date: "Dec 15, 2024",
+    readingTime: "8 min read",
+    url: "https://medium.com/design-bootcamp/extended-pausabilities-navigating-xr-with-accessibility-in-mind-1fa35fb4d590",
+    image: `/api/placeholder?width=600&height=400&text=${encodeURIComponent('Extended Pausabilities')}`,
+    publication: "Bootcamp",
+    featured: false,
+  },
+  {
+    id: "redefining-reality",
+    title: "Redefining Reality: The Future of Design in XR",
+    excerpt:
+      "How extended reality is transforming design principles and creating new possibilities for immersive experiences.",
+    date: "Nov 30, 2024",
+    readingTime: "6 min read",
+    url: "https://medium.com/design-bootcamp/redefining-reality-the-future-of-design-in-xr-a5e053e255a8",
+    image: `/api/placeholder?width=600&height=400&text=${encodeURIComponent('Redefining Reality')}`,
+    publication: "Bootcamp",
+    featured: false,
+  },
+]

--- a/types/post.ts
+++ b/types/post.ts
@@ -1,0 +1,11 @@
+export interface Post {
+  id: string
+  title: string
+  excerpt: string
+  date: string
+  readingTime: string
+  url: string
+  image: string
+  publication: string
+  featured: boolean
+}


### PR DESCRIPTION
## Summary
- add `types/post.ts` to describe blog post data
- move posts array to `lib/posts.ts`
- update blog index page to import posts
- update individual posts to use centralized post metadata

## Testing
- `pnpm test`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6869a69f8c98832b8528edcd7c846961