### PR TITLE
Add hidden label for project filter input

### DIFF
--- a/components/project-filter.tsx
+++ b/components/project-filter.tsx
@@ -71,7 +71,11 @@ export function ProjectFilter({ featured, projects }: ProjectFilterProps) {
         className="flex flex-col sm:flex-row gap-2"
         onSubmit={handleSubmit}
       >
+        <label htmlFor="project-keyword" className="sr-only">
+          Enter a keyword
+        </label>
         <Input
+          id="project-keyword"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Enter a keyword"

--- a/components/project-filter.tsx
+++ b/components/project-filter.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useCallback, type FormEvent } from "react"
+import { useState, useEffect, useCallback, useId, type FormEvent } from "react"
 import { ProjectCard } from "@/components/project-card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -22,6 +22,7 @@ export function ProjectFilter({ featured, projects }: ProjectFilterProps) {
   const [query, setQuery] = useState("")
   const [personalized, setPersonalized] = useState(false)
   const [display, setDisplay] = useState<Project[]>(featured)
+  const inputId = useId()
 
   useEffect(() => {
     setDisplay(featured)
@@ -71,11 +72,11 @@ export function ProjectFilter({ featured, projects }: ProjectFilterProps) {
         className="flex flex-col sm:flex-row gap-2"
         onSubmit={handleSubmit}
       >
-        <label htmlFor="project-keyword" className="sr-only">
-          Enter a keyword
+        <label htmlFor={inputId} className="sr-only">
+          Filter by keyword
         </label>
         <Input
-          id="project-keyword"
+          id={inputId}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Enter a keyword"


### PR DESCRIPTION
## Summary
- include a visually-hidden label for the keyword search in `ProjectFilter`

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869b33e0a54832bbdbb1c184a479437