### PR TITLE
Reduce duplication in image navigation handlers

### DIFF
--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -846,7 +846,6 @@ export default function ProjectPage() {
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (selectedIndex === null) return
       if (e.key === "ArrowRight") {
         handleNext()
       } else if (e.key === "ArrowLeft") {
@@ -855,7 +854,7 @@ export default function ProjectPage() {
     }
     window.addEventListener("keydown", handleKey)
     return () => window.removeEventListener("keydown", handleKey)
-  }, [selectedIndex, handleNext, handlePrev])
+  }, [handleNext, handlePrev])
 
   return (
     <div className="space-y-8 pt-8">

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -830,18 +830,32 @@ export default function ProjectPage() {
 
   const images = [project.image, ...(project.gallery || [])]
 
+  const handlePrev = useCallback(() => {
+    setSelectedIndex((i) => {
+      if (i === null) return null
+      return (i - 1 + images.length) % images.length
+    })
+  }, [images.length])
+
+  const handleNext = useCallback(() => {
+    setSelectedIndex((i) => {
+      if (i === null) return null
+      return (i + 1) % images.length
+    })
+  }, [images.length])
+
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       if (selectedIndex === null) return
       if (e.key === "ArrowRight") {
-        setSelectedIndex((i) => (i !== null ? (i + 1) % images.length : i))
+        handleNext()
       } else if (e.key === "ArrowLeft") {
-        setSelectedIndex((i) => (i !== null ? (i - 1 + images.length) % images.length : i))
+        handlePrev()
       }
     }
     window.addEventListener("keydown", handleKey)
     return () => window.removeEventListener("keydown", handleKey)
-  }, [selectedIndex, images.length])
+  }, [selectedIndex, handleNext, handlePrev])
 
   return (
     <div className="space-y-8 pt-8">
@@ -1058,8 +1072,8 @@ export default function ProjectPage() {
         onOpenChange={(o) => !o && closeModal()}
         src={selectedIndex !== null ? images[selectedIndex] : ""}
         alt={project.title}
-        onPrev={() => setSelectedIndex((i) => (i !== null ? (i - 1 + images.length) % images.length : i))}
-        onNext={() => setSelectedIndex((i) => (i !== null ? (i + 1) % images.length : i))}
+        onPrev={handlePrev}
+        onNext={handleNext}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- extract image navigation callbacks
- reuse callbacks in keyboard handler and ImageModal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869ba50ad8c832ba9f7f528ead253d0