### PR TITLE
Add aria-hidden attributes to background effects

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -48,7 +48,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${jetbrainsMono.variable} font-mono bg-black text-white min-h-screen flex flex-col`}>
-        <div className="fixed inset-0 bg-grid-pattern opacity-10 pointer-events-none z-0"></div>
+        <div
+          className="fixed inset-0 bg-grid-pattern opacity-10 pointer-events-none z-0"
+          aria-hidden="true"
+        ></div>
 
         {/* No fallback - let MetaverseNav handle its own loading */}
         <Suspense>

--- a/components/katana-cursor.tsx
+++ b/components/katana-cursor.tsx
@@ -76,6 +76,7 @@ export function KatanaCursor() {
     <>
       <motion.div
         className="fixed z-[1000] pointer-events-none"
+        aria-hidden="true"
         animate={{
           x: position.x,
           y: position.y,

--- a/components/sumerian-virus.tsx
+++ b/components/sumerian-virus.tsx
@@ -116,6 +116,7 @@ export function SumerianVirus() {
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
+          aria-hidden="true"
         >
           {/* Background glyph stream */}
           <div className="absolute inset-0 text-primary/20 overflow-hidden pointer-events-none select-none">


### PR DESCRIPTION
## Summary
- hide animated grid background from screen readers
- mark SumerianVirus overlay as aria-hidden
- mark KatanaCursor overlay as aria-hidden

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686aa7050d8c832bb606b37389cc2be3