### PR TITLE
Wrap Metaverse nav in landmark

### DIFF
--- a/app/clientLayout.tsx
+++ b/app/clientLayout.tsx
@@ -37,9 +37,11 @@ export default function RootLayout({
     <html lang="en">
       <body className="bg-black text-white min-h-screen flex flex-col">
         <KatanaCursor />
-        <Suspense fallback={<NavigationFallback />}>
-          <MetaverseNavFallback />
-        </Suspense>
+        <nav aria-label="Metaverse navigation">
+          <Suspense fallback={<NavigationFallback />}>
+            <MetaverseNavFallback />
+          </Suspense>
+        </nav>
         <Navigation />
         <main className="flex-grow">{children}</main>
         <Footer />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -54,9 +54,11 @@ export default function RootLayout({
         ></div>
 
         {/* No fallback - let MetaverseNav handle its own loading */}
-        <Suspense>
-          <MetaverseNav />
-        </Suspense>
+        <nav aria-label="Metaverse navigation">
+          <Suspense>
+            <MetaverseNav />
+          </Suspense>
+        </nav>
 
         <main className="flex-1 container mx-auto px-4 pt-20 pb-8 relative z-10">{children}</main>
         <Footer />


### PR DESCRIPTION
## Summary
- ensure Metaverse navigation is inside a `<nav>` landmark in all layouts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686aac6ef368832b8df2775df865e5a6