### PR TITLE
Ensure color pairs meet WCAG contrast

### DIFF
--- a/__tests__/contrast.test.ts
+++ b/__tests__/contrast.test.ts
@@ -39,11 +39,7 @@ function convert(value: string): string {
   if (value.startsWith('#')) {
     return value.toLowerCase();
   }
-  const match = value.match(/([0-9.]+)\s+([0-9.]+)%\s+([0-9.]+)%/);
-  if (!match) {
-    throw new Error(`Unable to parse color: ${value}`);
-  }
-  return hslToHex(parseFloat(match[1]), parseFloat(match[2]), parseFloat(match[3]));
+  const match = value.match(/^hsl\(\s*([0-9.]+)\s*,\s*([0-9.]+)%\s*,\s*([0-9.]+)%\s*\)$/);
 }
 
 const css = fs.readFileSync('styles/globals.css', 'utf8');

--- a/__tests__/contrast.test.ts
+++ b/__tests__/contrast.test.ts
@@ -1,0 +1,87 @@
+import fs from 'fs';
+import { hex as contrastHex } from 'wcag-contrast';
+
+function parseColors(block: string): Record<string, string> {
+  const vars: Record<string, string> = {};
+  const regex = /--([a-z0-9-]+):\s*([^;]+);/gi;
+  let m;
+  while ((m = regex.exec(block))) {
+    vars[m[1]] = m[2].trim();
+  }
+  return vars;
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  s /= 100;
+  l /= 100;
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+  let r = 0, g = 0, b = 0;
+  if (h < 60) {
+    r = c; g = x; b = 0;
+  } else if (h < 120) {
+    r = x; g = c; b = 0;
+  } else if (h < 180) {
+    r = 0; g = c; b = x;
+  } else if (h < 240) {
+    r = 0; g = x; b = c;
+  } else if (h < 300) {
+    r = x; g = 0; b = c;
+  } else {
+    r = c; g = 0; b = x;
+  }
+  const to255 = (n: number) => Math.round((n + m) * 255);
+  return `#${to255(r).toString(16).padStart(2, '0')}${to255(g).toString(16).padStart(2, '0')}${to255(b).toString(16).padStart(2, '0')}`;
+}
+
+function convert(value: string): string {
+  if (value.startsWith('#')) {
+    return value.toLowerCase();
+  }
+  const match = value.match(/([0-9.]+)\s+([0-9.]+)%\s+([0-9.]+)%/);
+  if (!match) {
+    throw new Error(`Unable to parse color: ${value}`);
+  }
+  return hslToHex(parseFloat(match[1]), parseFloat(match[2]), parseFloat(match[3]));
+}
+
+const css = fs.readFileSync('styles/globals.css', 'utf8');
+const rootMatch = /:root\s*{([^}]*)}/.exec(css);
+const darkMatch = /\.dark\s*{([^}]*)}/.exec(css);
+if (!rootMatch || !darkMatch) {
+  throw new Error('Unable to find color blocks');
+}
+
+const rootColors = parseColors(rootMatch[1]);
+const darkColors = parseColors(darkMatch[1]);
+
+const pairs: Record<string, string> = {
+  foreground: 'background',
+  'card-foreground': 'card',
+  'popover-foreground': 'popover',
+  'primary-foreground': 'primary',
+  'secondary-foreground': 'secondary',
+  'muted-foreground': 'muted',
+  'accent-foreground': 'accent',
+  'destructive-foreground': 'destructive',
+  'sidebar-foreground': 'sidebar-background',
+  'sidebar-primary-foreground': 'sidebar-primary',
+  'sidebar-accent-foreground': 'sidebar-accent',
+};
+
+function checkPairs(colors: Record<string, string>) {
+  for (const [fg, bg] of Object.entries(pairs)) {
+    if (!(fg in colors) || !(bg in colors)) continue;
+    const ratio = contrastHex(convert(colors[fg]), convert(colors[bg]));
+    expect(ratio).toBeGreaterThanOrEqual(3);
+  }
+}
+
+test('light theme color contrast', () => {
+  checkPairs(rootColors);
+});
+
+test('dark theme color contrast', () => {
+  checkPairs(darkColors);
+});

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "postcss": "^8.5",
     "tailwindcss": "^3.4.17",
     "ts-jest": "^29.4.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "wcag-contrast": "^3.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.0.2
+      wcag-contrast:
+        specifier: ^3.0.0
+        version: 3.0.0
 
 packages:
 
@@ -3580,6 +3583,10 @@ packages:
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
+  esm@3.2.25:
+    resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
+    engines: {node: '>=6'}
+
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -5316,6 +5323,9 @@ packages:
     resolution: {integrity: sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==}
     hasBin: true
 
+  relative-luminance@2.0.1:
+    resolution: {integrity: sha512-wFuITNthJilFPwkK7gNJcULxXBcfFZvZORsvdvxeOdO44wCeZnuQkf3nFFzOR/dpJNxYsdRZJLsepWbyKhnMww==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -6032,6 +6042,9 @@ packages:
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
+  wcag-contrast@3.0.0:
+    resolution: {integrity: sha512-RWbpg/S7FOXDCwqC2oFhN/vh8dHzj0OS6dpyOSDHyQFSmqmR+lAUStV/ziTT1GzDqL9wol+nZQB4vCi5yEak+w==}
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
@@ -10146,6 +10159,8 @@ snapshots:
 
   esm-env@1.2.2: {}
 
+  esm@3.2.25: {}
+
   espree@10.4.0:
     dependencies:
       acorn: 8.15.0
@@ -12201,6 +12216,10 @@ snapshots:
     dependencies:
       jsesc: 3.0.2
 
+  relative-luminance@2.0.1:
+    dependencies:
+      esm: 3.2.25
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -13029,6 +13048,10 @@ snapshots:
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
+
+  wcag-contrast@3.0.0:
+    dependencies:
+      relative-luminance: 2.0.1
 
   wcwidth@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- add `wcag-contrast` dependency
- test color pairs in `globals.css` to verify a contrast ratio of at least 3:1

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686ab750fdc8832b8887b5d7954f8180