### PR TITLE
Lazy load analytics and disable font preload

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type React from "react"
 import type { Metadata } from "next"
 import { JetBrains_Mono } from "next/font/google"
+import Script from "next/script"
 import { Suspense } from "react"
 import "./globals.css"
 import { Footer } from "@/components/footer"
@@ -21,6 +22,7 @@ const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
   variable: "--font-mono",
   display: "swap",
+  preload: false,
 })
 
 export const metadata: Metadata = {
@@ -71,7 +73,9 @@ export default function RootLayout({
         <LabelsProvider>
           <Toaster />
         </LabelsProvider>
-        <Analytics />
+        <Script strategy="lazyOnload" id="vercel-analytics">
+          <Analytics />
+        </Script>
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary
- lazy load the analytics script using `<Script strategy="lazyOnload" id="vercel-analytics">`
- disable JetBrains_Mono font preload

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686ab7305af0832b97b96ec33efca9ce