### PR TITLE
Optimize heavy components with dynamic imports

### DIFF
--- a/__tests__/contrast.test.ts
+++ b/__tests__/contrast.test.ts
@@ -39,7 +39,13 @@ function convert(value: string): string {
   if (value.startsWith('#')) {
     return value.toLowerCase();
   }
-  const match = value.match(/^hsl\(\s*([0-9.]+)\s*,\s*([0-9.]+)%\s*,\s*([0-9.]+)%\s*\)$/);
+  const match =
+    value.match(/^hsl\(\s*([0-9.]+)\s*,\s*([0-9.]+)%\s*,\s*([0-9.]+)%\s*\)$/) ||
+    value.match(/([0-9.]+)\s+([0-9.]+)%\s+([0-9.]+)%/);
+  if (!match) {
+    throw new Error(`Unable to parse color: ${value}`);
+  }
+  return hslToHex(parseFloat(match[1]), parseFloat(match[2]), parseFloat(match[3]));
 }
 
 const css = fs.readFileSync('styles/globals.css', 'utf8');

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type React from "react"
 import type { Metadata } from "next"
 import { JetBrains_Mono } from "next/font/google"
 import { Suspense } from "react"
+import dynamic from "next/dynamic"
 import "./globals.css"
 import { Footer } from "@/components/footer"
 import { Analytics } from "@vercel/analytics/react"
@@ -12,9 +13,18 @@ import { config } from "@fortawesome/fontawesome-svg-core"
 config.autoAddCss = false
 
 // Import our Snow Crash inspired components
-import { MetaverseNav } from "@/components/metaverse-nav"
-import { SumerianVirus } from "@/components/sumerian-virus"
-import { KatanaCursor } from "@/components/katana-cursor"
+const MetaverseNav = dynamic(
+  () => import("@/components/metaverse-nav").then((m) => m.MetaverseNav),
+  { ssr: false }
+)
+const SumerianVirus = dynamic(
+  () => import("@/components/sumerian-virus").then((m) => m.SumerianVirus),
+  { ssr: false }
+)
+const KatanaCursor = dynamic(
+  () => import("@/components/katana-cursor").then((m) => m.KatanaCursor),
+  { ssr: false }
+)
 import { LabelsProvider } from "@/components/labels-provider"
 
 const jetbrainsMono = JetBrains_Mono({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,11 @@ import { ProjectCard } from "@/components/project-card"
 import { ProjectFilter } from "@/components/project-filter"
 import { BlogCard } from "@/components/blog-card"
 import { ArrowRight } from "lucide-react"
-import { HeroBackground } from "@/components/hero-background"
+import dynamic from "next/dynamic"
+const HeroBackground = dynamic(
+  () => import("@/components/hero-background").then((m) => m.HeroBackground),
+  { ssr: false }
+)
 import { RecentHighlights } from "@/components/recent-highlights"
 
 const allProjects = [


### PR DESCRIPTION
## Summary
- defer large Three.js components using `next/dynamic`
- update contrast test helper to parse plain HSL values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686ac52c98fc832bbe0dd9cee7ccfa42