### PR TITLE
Update alt text in recent highlights

### DIFF
--- a/components/recent-highlights.tsx
+++ b/components/recent-highlights.tsx
@@ -56,7 +56,7 @@ export function RecentHighlights() {
                     h.event
                   )}`
                 }
-                alt={`Thumbnail for ${h.event}`}
+                alt={h.event}
                 fill
                 className="object-cover rounded"
               />


### PR DESCRIPTION
## Summary
- use the event name for each highlight image's alt text

## Testing
- `pnpm lint`
- `pnpm test` *(fails: TypeError in contrast test)*
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_686acb75cd24832b994ce9cfbfc66ac2