### PR TITLE
Add SnowCrashEffects component and update layout

### DIFF
--- a/__tests__/contrast.test.ts
+++ b/__tests__/contrast.test.ts
@@ -39,7 +39,15 @@ function convert(value: string): string {
   if (value.startsWith('#')) {
     return value.toLowerCase();
   }
-  const match = value.match(/^hsl\(\s*([0-9.]+)\s*,\s*([0-9.]+)%\s*,\s*([0-9.]+)%\s*\)$/);
+  let match = value.match(/^hsl\(\s*([0-9.]+)\s*,\s*([0-9.]+)%\s*,\s*([0-9.]+)%\s*\)$/);
+  if (match) {
+    return hslToHex(parseFloat(match[1]), parseFloat(match[2]), parseFloat(match[3]));
+  }
+  match = value.match(/^([0-9.]+)\s+([0-9.]+)%\s+([0-9.]+)%$/);
+  if (!match) {
+    throw new Error(`Unable to parse color: ${value}`);
+  }
+  return hslToHex(parseFloat(match[1]), parseFloat(match[2]), parseFloat(match[3]));
 }
 
 const css = fs.readFileSync('styles/globals.css', 'utf8');

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,9 +12,7 @@ import { config } from "@fortawesome/fontawesome-svg-core"
 config.autoAddCss = false
 
 // Import our Snow Crash inspired components
-import { MetaverseNav } from "@/components/metaverse-nav"
-import { SumerianVirus } from "@/components/sumerian-virus"
-import { KatanaCursor } from "@/components/katana-cursor"
+import { SnowCrashEffects } from "@/components/snow-crash-effects"
 import { LabelsProvider } from "@/components/labels-provider"
 
 const jetbrainsMono = JetBrains_Mono({
@@ -56,9 +54,7 @@ export default function RootLayout({
         ></div>
 
         {/* No fallback - let MetaverseNav handle its own loading */}
-        <Suspense>
-          <MetaverseNav />
-        </Suspense>
+        <SnowCrashEffects />
 
         <main className="flex-1 container mx-auto px-4 pt-20 pb-8 relative z-10">
           {children}
@@ -66,8 +62,7 @@ export default function RootLayout({
         <Footer />
 
         {/* Add our Snow Crash inspired components */}
-        <SumerianVirus />
-        <KatanaCursor />
+        {/* SnowCrashEffects already includes SumerianVirus and KatanaCursor */}
 
         <LabelsProvider>
           <Toaster />

--- a/components/snow-crash-effects.tsx
+++ b/components/snow-crash-effects.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { Suspense } from 'react'
+
+const MetaverseNav = dynamic(() => import('./metaverse-nav').then(m => m.MetaverseNav), { ssr: false })
+const SumerianVirus = dynamic(() => import('./sumerian-virus').then(m => m.SumerianVirus), { ssr: false })
+const KatanaCursor = dynamic(() => import('./katana-cursor').then(m => m.KatanaCursor), { ssr: false })
+
+export function SnowCrashEffects() {
+  return (
+    <Suspense>
+      <>
+        <MetaverseNav />
+        <SumerianVirus />
+        <KatanaCursor />
+      </>
+    </Suspense>
+  )
+}


### PR DESCRIPTION
## Summary
- create `SnowCrashEffects` component that dynamically loads MetaverseNav, SumerianVirus, and KatanaCursor
- replace individual imports in `layout.tsx` with `SnowCrashEffects`
- fix color conversion helper in contrast tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686acc482940832ba847cdeaa8f2ca8b