### PR TITLE
Fix loading overlay landmark issue

### DIFF
--- a/components/metaverse-nav.tsx
+++ b/components/metaverse-nav.tsx
@@ -491,17 +491,16 @@ export function MetaverseNav() {
         <div className="absolute bottom-4 left-0 right-0 text-center text-xs text-zinc-500">
           Navigate The Street by clicking on destinations
         </div>
+        <motion.div
+          className="fixed inset-0 bg-black z-[60] flex items-center justify-center"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: transitioning ? 1 : 0, pointerEvents: transitioning ? "auto" : "none" }}
+        >
+          <div className="text-primary text-2xl font-bold glitch" data-text="LOADING STREET...">
+            LOADING STREET...
+          </div>
+        </motion.div>
       </motion.nav>
-
-      <motion.div
-        className="fixed inset-0 bg-black z-[60] flex items-center justify-center"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: transitioning ? 1 : 0, pointerEvents: transitioning ? "auto" : "none" }}
-      >
-        <div className="text-primary text-2xl font-bold glitch" data-text="LOADING STREET...">
-          LOADING STREET...
-        </div>
-      </motion.div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- keep loading overlay within navigation landmark

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686b2144aac8832ba434eb32861aacbf