### PR TITLE
Dynamic import for MetaverseNav

### DIFF
--- a/components/snow-crash-effects.tsx
+++ b/components/snow-crash-effects.tsx
@@ -2,7 +2,17 @@
 
 import dynamic from 'next/dynamic'
 import { Suspense } from 'react'
-const MetaverseNav = dynamic(() => import('./metaverse-nav').then(m => m.MetaverseNav), { ssr: false })
+const MetaverseNav = dynamic(
+  () => import('./metaverse-nav').then((m) => m.MetaverseNav),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="fixed top-0 left-0 w-full z-50">
+        <header className="h-20 border-b border-border/40 backdrop-blur-sm" />
+      </div>
+    ),
+  },
+)
 
 // Only non-essential effects are dynamically loaded to keep the initial
 // bundle small while ensuring the main navigation is present immediately.

--- a/components/snow-crash-effects.tsx
+++ b/components/snow-crash-effects.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from 'next/dynamic'
 import { Suspense } from 'react'
-import { MetaverseNav } from './metaverse-nav'
+const MetaverseNav = dynamic(() => import('./metaverse-nav').then(m => m.MetaverseNav), { ssr: false })
 
 // Only non-essential effects are dynamically loaded to keep the initial
 // bundle small while ensuring the main navigation is present immediately.


### PR DESCRIPTION
## Summary
- load MetaverseNav using next/dynamic to keep core bundle smaller
- keep SumerianVirus and KatanaCursor dynamic imports

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686b2dc878b4832bab543d54a6f6a31f