### PR TITLE
Add test for empty cn

### DIFF
--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -31,4 +31,8 @@ describe('cn', () => {
     )
   })
 
+  it('returns an empty string when called with no arguments', () => {
+    expect(cn()).toBe('')
+  })
+
 })


### PR DESCRIPTION
## Summary
- cover calling `cn()` without arguments

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686b31563294832bbe59817900661c2a