### PR TITLE
fix toast update type

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -155,7 +155,7 @@ function toast({ ...props }: Toast) {
   }
   const id = genId()
 
-  const update = (props: Partial<ToasterToast>) =>
+  const update = (props: Omit<Partial<ToasterToast>, "id">) =>
     dispatch({
       type: "UPDATE_TOAST",
       toast: { ...props, id },

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -155,7 +155,7 @@ function toast({ ...props }: Toast) {
   }
   const id = genId()
 
-  const update = (props: ToasterToast) =>
+  const update = (props: Partial<ToasterToast>) =>
     dispatch({
       type: "UPDATE_TOAST",
       toast: { ...props, id },


### PR DESCRIPTION
## Summary
- fix typings for `update` in `use-toast`

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property `mesh` does not exist on type 'JSX.IntrinsicElements', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686b313c1750832b84ff28b18490c2ee