### PR TITLE
Cache viewport size for animations

### DIFF
--- a/components/hero-background.tsx
+++ b/components/hero-background.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useRef, useEffect, useState } from "react"
+import { useViewportSize } from "@/hooks/use-viewport-size"
 import * as THREE from "three"
 
 // Import THREE from the same source to avoid duplicate instances
@@ -14,11 +15,12 @@ export function HeroBackground() {
   const frameRef = useRef<number>(0)
   const mousePosition = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
   const [isMobile, setIsMobile] = useState(false)
+  const viewport = useViewportSize()
 
   useEffect(() => {
     // Check if we're on a mobile device
     const checkMobile = () => {
-      setIsMobile(window.innerWidth < 768)
+      setIsMobile(viewport.current.width < 768)
     }
 
     // Initial check
@@ -40,13 +42,18 @@ export function HeroBackground() {
     sceneRef.current = scene
 
     // Initialize camera
-    const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000)
+    const camera = new THREE.PerspectiveCamera(
+      60,
+      viewport.current.width / viewport.current.height,
+      0.1,
+      1000,
+    )
     camera.position.z = 20
     cameraRef.current = camera
 
     // Initialize renderer
     const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true })
-    renderer.setSize(window.innerWidth, window.innerHeight)
+    renderer.setSize(viewport.current.width, viewport.current.height)
     renderer.setClearColor(0x000000, 0) // Transparent background
     containerRef.current.appendChild(renderer.domElement)
     rendererRef.current = renderer
@@ -241,8 +248,8 @@ export function HeroBackground() {
 
     // Track mouse movement for subtle interactivity
     const handleMouseMove = (event: MouseEvent) => {
-      mousePosition.current.x = (event.clientX / window.innerWidth) * 2 - 1
-      mousePosition.current.y = -(event.clientY / window.innerHeight) * 2 + 1
+      mousePosition.current.x = (event.clientX / viewport.current.width) * 2 - 1
+      mousePosition.current.y = -(event.clientY / viewport.current.height) * 2 + 1
     }
 
     window.addEventListener("mousemove", handleMouseMove)
@@ -311,9 +318,9 @@ export function HeroBackground() {
     const handleResize = () => {
       if (!cameraRef.current || !rendererRef.current) return
 
-      cameraRef.current.aspect = window.innerWidth / window.innerHeight
+      cameraRef.current.aspect = viewport.current.width / viewport.current.height
       cameraRef.current.updateProjectionMatrix()
-      rendererRef.current.setSize(window.innerWidth, window.innerHeight)
+      rendererRef.current.setSize(viewport.current.width, viewport.current.height)
 
       if (particleMaterial.uniforms) {
         particleMaterial.uniforms.pixelRatio.value = window.devicePixelRatio

--- a/components/hero-background.tsx
+++ b/components/hero-background.tsx
@@ -20,7 +20,7 @@ export function HeroBackground() {
   useEffect(() => {
     // Check if we're on a mobile device
     const checkMobile = () => {
-      setIsMobile(viewport.current.width < 768)
+      setIsMobile(viewport.width < 768)
     }
 
     // Initial check
@@ -44,7 +44,7 @@ export function HeroBackground() {
     // Initialize camera
     const camera = new THREE.PerspectiveCamera(
       60,
-      viewport.current.width / viewport.current.height,
+      viewport.width / viewport.height,
       0.1,
       1000,
     )
@@ -53,7 +53,7 @@ export function HeroBackground() {
 
     // Initialize renderer
     const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true })
-    renderer.setSize(viewport.current.width, viewport.current.height)
+    renderer.setSize(viewport.width, viewport.height)
     renderer.setClearColor(0x000000, 0) // Transparent background
     containerRef.current.appendChild(renderer.domElement)
     rendererRef.current = renderer
@@ -248,8 +248,8 @@ export function HeroBackground() {
 
     // Track mouse movement for subtle interactivity
     const handleMouseMove = (event: MouseEvent) => {
-      mousePosition.current.x = (event.clientX / viewport.current.width) * 2 - 1
-      mousePosition.current.y = -(event.clientY / viewport.current.height) * 2 + 1
+      mousePosition.current.x = (event.clientX / viewport.width) * 2 - 1
+      mousePosition.current.y = -(event.clientY / viewport.height) * 2 + 1
     }
 
     window.addEventListener("mousemove", handleMouseMove)
@@ -318,9 +318,9 @@ export function HeroBackground() {
     const handleResize = () => {
       if (!cameraRef.current || !rendererRef.current) return
 
-      cameraRef.current.aspect = viewport.current.width / viewport.current.height
+      cameraRef.current.aspect = viewport.width / viewport.height
       cameraRef.current.updateProjectionMatrix()
-      rendererRef.current.setSize(viewport.current.width, viewport.current.height)
+      rendererRef.current.setSize(viewport.width, viewport.height)
 
       if (particleMaterial.uniforms) {
         particleMaterial.uniforms.pixelRatio.value = window.devicePixelRatio

--- a/components/katana-cursor.tsx
+++ b/components/katana-cursor.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import { useViewportSize } from "@/hooks/use-viewport-size"
 import { motion } from "framer-motion"
 
 export function KatanaCursor() {
@@ -8,6 +9,7 @@ export function KatanaCursor() {
   const [isVisible, setIsVisible] = useState(false)
   const [isSlashing, setIsSlashing] = useState(false)
   const [isTouchDevice, setIsTouchDevice] = useState(false)
+  const viewport = useViewportSize()
 
   useEffect(() => {
     // More reliable touch device detection
@@ -17,7 +19,7 @@ export function KatanaCursor() {
       const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
 
       // Additional check for small screen sizes typical of mobile devices
-      const isSmallScreen = window.innerWidth < 768
+      const isSmallScreen = viewport.current.width < 768
 
       setIsTouchDevice(isMobile || isSmallScreen)
     }

--- a/components/katana-cursor.tsx
+++ b/components/katana-cursor.tsx
@@ -19,7 +19,7 @@ export function KatanaCursor() {
       const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
 
       // Additional check for small screen sizes typical of mobile devices
-      const isSmallScreen = viewport.current.width < 768
+      const isSmallScreen = viewport.width < 768
 
       setIsTouchDevice(isMobile || isSmallScreen)
     }

--- a/components/sumerian-virus.tsx
+++ b/components/sumerian-virus.tsx
@@ -130,11 +130,11 @@ export function SumerianVirus() {
                 className="absolute text-xl"
                 initial={{
                   opacity: 1,
-                  x: Math.random() * viewport.current.width,
+                  x: Math.random() * viewport.width,
                   y: -30,
                 }}
                 animate={{
-                  y: viewport.current.height + 30,
+                  y: viewport.height + 30,
                   opacity: [1, 0.8, 0.6, 0.4, 0.2, 0],
                 }}
                 transition={{

--- a/components/sumerian-virus.tsx
+++ b/components/sumerian-virus.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import { useViewportSize } from "@/hooks/use-viewport-size"
 import { motion, AnimatePresence } from "framer-motion"
 
 // Sumerian-inspired glyphs
@@ -49,6 +50,7 @@ export function SumerianVirus() {
   const [isActive, setIsActive] = useState(false)
   const [glyphStream, setGlyphStream] = useState<string[]>([])
   const [message, setMessage] = useState("")
+  const viewport = useViewportSize()
 
   // Messages that will be displayed during the "infection"
   const messages = [
@@ -128,11 +130,11 @@ export function SumerianVirus() {
                 className="absolute text-xl"
                 initial={{
                   opacity: 1,
-                  x: Math.random() * window.innerWidth,
+                  x: Math.random() * viewport.current.width,
                   y: -30,
                 }}
                 animate={{
-                  y: window.innerHeight + 30,
+                  y: viewport.current.height + 30,
                   opacity: [1, 0.8, 0.6, 0.4, 0.2, 0],
                 }}
                 transition={{

--- a/hooks/use-viewport-size.ts
+++ b/hooks/use-viewport-size.ts
@@ -1,20 +1,24 @@
 "use client"
 
-import { useRef, useEffect } from "react"
+import { useState, useEffect } from "react"
 
 export function useViewportSize() {
-  const sizeRef = useRef({ width: 0, height: 0 })
+  const [size, setSize] = useState({
+    width: typeof window !== "undefined" ? window.innerWidth : 0,
+    height: typeof window !== "undefined" ? window.innerHeight : 0,
+  })
 
   useEffect(() => {
-    const updateSize = () => {
-      sizeRef.current.width = window.innerWidth
-      sizeRef.current.height = window.innerHeight
+    const handleResize = () => {
+      setSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      })
     }
 
-    updateSize()
-    window.addEventListener("resize", updateSize)
-    return () => window.removeEventListener("resize", updateSize)
+    window.addEventListener("resize", handleResize)
+    return () => window.removeEventListener("resize", handleResize)
   }, [])
 
-  return sizeRef
+  return size
 }

--- a/hooks/use-viewport-size.ts
+++ b/hooks/use-viewport-size.ts
@@ -1,0 +1,20 @@
+"use client"
+
+import { useRef, useEffect } from "react"
+
+export function useViewportSize() {
+  const sizeRef = useRef({ width: 0, height: 0 })
+
+  useEffect(() => {
+    const updateSize = () => {
+      sizeRef.current.width = window.innerWidth
+      sizeRef.current.height = window.innerHeight
+    }
+
+    updateSize()
+    window.addEventListener("resize", updateSize)
+    return () => window.removeEventListener("resize", updateSize)
+  }, [])
+
+  return sizeRef
+}


### PR DESCRIPTION
## Summary
- create `useViewportSize` hook to store viewport width/height
- use cached viewport size in `HeroBackground`, `KatanaCursor`, and `SumerianVirus`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686b3fa10794832b9eed3f8fdaf89935