### PR TITLE
Add invalid color test for convert

### DIFF
--- a/__tests__/contrast.test.ts
+++ b/__tests__/contrast.test.ts
@@ -97,3 +97,7 @@ test('convert parses hsl formats', () => {
   expect(convert('hsl(43 74% 66%)')).toBe('#e8c468');
   expect(convert('hsl(43,74%,66%)')).toBe('#e8c468');
 });
+
+test('convert throws on invalid color string', () => {
+  expect(() => convert('not-a-color')).toThrow();
+});

--- a/__tests__/contrast.test.ts
+++ b/__tests__/contrast.test.ts
@@ -98,6 +98,11 @@ test('convert parses hsl formats', () => {
   expect(convert('hsl(43,74%,66%)')).toBe('#e8c468');
 });
 
-test('convert throws on invalid color string', () => {
-  expect(() => convert('not-a-color')).toThrow();
+test.each([
+  ['not-a-color'],
+  ['hsl(invalid)'],
+  ['1 2 3'], // missing '%'
+  [''], // empty string
+])('convert throws on invalid color string "%s"', (color) => {
+  expect(() => convert(color)).toThrow(`Unable to parse color: ${color}`);
 });


### PR DESCRIPTION
## Summary
- extend tests for the `convert` helper
- verify it throws an error on invalid color strings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b44053018832b8c910fd16fb81902