### PR TITLE
Add hex string case to contrast tests

### DIFF
--- a/__tests__/contrast.test.ts
+++ b/__tests__/contrast.test.ts
@@ -98,6 +98,10 @@ test('convert parses hsl formats', () => {
   expect(convert('hsl(43,74%,66%)')).toBe('#e8c468');
 });
 
+test('convert lowercases hex strings', () => {
+  expect(convert('#ABCDEF')).toBe('#abcdef');
+});
+
 test.each([
   ['not-a-color'],
   ['hsl(invalid)'],


### PR DESCRIPTION
## Summary
- ensure convert lowercases hex strings in `contrast.test.ts`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686b57caff34832b9578c935d30d03ae