### PR TITLE
Fix metaverse nav import in client layout

### DIFF
--- a/app/clientLayout.tsx
+++ b/app/clientLayout.tsx
@@ -5,7 +5,7 @@ import type React from "react"
 import "./globals.css"
 import { Navigation } from "@/components/navigation"
 import { Footer } from "@/components/footer"
-import { MetaverseNavFallback } from "@/components/metaverse-nav-fallback"
+import { MetaverseNav } from "@/components/metaverse-nav"
 import { KatanaCursor } from "@/components/katana-cursor"
 
 // Loading fallback for navigation components that use client-side hooks
@@ -38,7 +38,7 @@ export default function RootLayout({
       <body className="bg-black text-white min-h-screen flex flex-col">
         <KatanaCursor />
         <Suspense fallback={<NavigationFallback />}>
-          <MetaverseNavFallback />
+          <MetaverseNav />
         </Suspense>
         <Navigation />
         <main className="flex-grow">{children}</main>


### PR DESCRIPTION
## Summary
- use `MetaverseNav` instead of missing `MetaverseNavFallback`
- render `<MetaverseNav />` inside `<Suspense>`

## Testing
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686b5c6f486c832bbfd8685262cac097