### PR TITLE
Remove unused next-themes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,12 @@
     "framer-motion": "latest",
     "lucide-react": "^0.454.0",
     "next": "15.2.4",
-    "next-themes": "latest",
     "react": "^19",
     "react-dom": "^19",
     "resend": "latest",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
-    "three": "latest",
-    "wcag-contrast": "^3.0.0"
+    "three": "latest"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
@@ -45,6 +43,7 @@
     "postcss": "^8.5",
     "tailwindcss": "^3.4.17",
     "ts-jest": "^29.4.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "wcag-contrast": "^3.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,6 @@ importers:
       next:
         specifier: 15.2.4
         version: 15.2.4(@babel/core@7.27.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      next-themes:
-        specifier: latest
-        version: 0.4.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: ^19
         version: 19.0.0
@@ -71,9 +68,6 @@ importers:
       three:
         specifier: latest
         version: 0.177.0
-      wcag-contrast:
-        specifier: ^3.0.0
-        version: 3.0.0
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -111,6 +105,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.0.2
+      wcag-contrast:
+        specifier: ^3.0.0
+        version: 3.0.0
 
 packages:
 
@@ -4073,12 +4070,6 @@ packages:
 
   nested-error-stacks@2.0.1:
     resolution: {integrity: sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==}
-
-  next-themes@0.4.6:
-    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
-    peerDependencies:
-      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@15.2.4:
     resolution: {integrity: sha512-VwL+LAaPSxEkd3lU2xWbgEOtrM8oedmyhBqaVNmgKB+GvZlCy9rgaEc+y2on0wv+l0oSFqLtYD6dcC1eAedUaQ==}
@@ -10492,11 +10483,6 @@ snapshots:
 
   nested-error-stacks@2.0.1:
     optional: true
-
-  next-themes@0.4.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
-    dependencies:
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
 
   next@15.2.4(@babel/core@7.27.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:


### PR DESCRIPTION
## Summary
- move `wcag-contrast` to devDependencies
- drop unused `next-themes`
- regenerate lockfile

## Testing
- `pnpm install`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_687b2bcb7b6c832b8f93a3f40c789261