### PR TITLE
Add CI workflow for pnpm lint and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           if [ -f .nvmrc ]; then
             echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
           else
-            echo "version=$(node -e \"const p=require('./package.json'); console.log(p.engines?.node || '20');\")" >> "$GITHUB_OUTPUT"
+            echo "version=$(node -e 'const p=require("./package.json"); console.log(p.engines?.node || "20");')" >> "$GITHUB_OUTPUT"
           fi
       - uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Determine Node version
+        id: node
+        run: |
+          if [ -f .nvmrc ]; then
+            echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$(node -e \"const p=require('./package.json'); console.log(p.engines?.node || '20');\")" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ steps.node.outputs.version }}
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm lint
+      - run: pnpm test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `pnpm install`, `pnpm lint`, and `pnpm test`
- auto-detect Node version from `.nvmrc` or `package.json` `engines` field, defaulting to Node 20

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687b3079f47c832b8b4589fa127a053f