### PR TITLE
[codex] Deepen industrial 3D homepage experience

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -155,7 +155,11 @@ html {
 
 .industrial-canvas {
   position: fixed;
-  inset: 0;
+  top: 0;
+  right: 0;
+  bottom: auto;
+  left: 0;
+  height: 100vh;
   z-index: 0;
   background:
     radial-gradient(circle at 50% 22%, rgba(255,255,255,0.07), transparent 16rem),
@@ -164,6 +168,148 @@ html {
 
 .industrial-canvas canvas {
   opacity: 0.9;
+}
+
+.industrial-atmosphere {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: auto;
+  left: 0;
+  height: 100vh;
+  z-index: 1;
+  pointer-events: none;
+  overflow: hidden;
+  opacity: 0.92;
+  transition: opacity 220ms ease;
+}
+
+.industrial-atmosphere::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background:
+    linear-gradient(90deg, rgba(0,0,0,0.98) 0 8%, rgba(0,0,0,0.72) 28%, transparent 48%, rgba(0,0,0,0.36) 74%, rgba(0,0,0,0.58) 100%),
+    radial-gradient(circle at 52% 31%, rgba(239,231,216,0.36), transparent 13rem),
+    radial-gradient(circle at 79% 35%, rgba(181,18,24,0.36), transparent 14rem),
+    radial-gradient(ellipse at 62% 78%, rgba(238,231,216,0.15), transparent 22rem),
+    linear-gradient(180deg, transparent 0 57%, rgba(0,0,0,0.65) 82%, #030303 100%);
+}
+
+.industrial-atmosphere::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+  background:
+    repeating-linear-gradient(90deg, transparent 0 56px, rgba(238,231,216,0.06) 57px, transparent 58px),
+    repeating-linear-gradient(0deg, transparent 0 52px, rgba(238,231,216,0.035) 53px, transparent 54px);
+  mask-image: linear-gradient(90deg, transparent 0 34%, black 48%, transparent 100%);
+  opacity: 0.72;
+}
+
+.industrial-atmosphere-screen {
+  position: absolute;
+  z-index: 2;
+  display: block;
+  width: min(24vw, 24rem);
+  height: min(25vh, 12rem);
+  border: 1px solid rgba(238,231,216,0.32);
+  background:
+    repeating-linear-gradient(0deg, rgba(238,231,216,0.34) 0 1px, transparent 1px 8px),
+    linear-gradient(135deg, rgba(238,231,216,0.28), rgba(181,18,24,0.12) 44%, rgba(238,231,216,0.05));
+  box-shadow:
+    inset 0 0 54px rgba(0,0,0,0.76),
+    0 0 70px rgba(238,231,216,0.2);
+  opacity: 0.86;
+  mix-blend-mode: screen;
+}
+
+.industrial-atmosphere-screen-left {
+  left: 28%;
+  top: 30%;
+  transform: perspective(780px) rotateY(34deg) rotateZ(-1deg);
+}
+
+.industrial-atmosphere-screen-right {
+  right: 3%;
+  top: 26%;
+  width: min(25vw, 26rem);
+  transform: perspective(760px) rotateY(-31deg) rotateZ(1deg);
+  background:
+    repeating-linear-gradient(0deg, rgba(238,231,216,0.34) 0 1px, transparent 1px 7px),
+    repeating-linear-gradient(90deg, rgba(238,231,216,0.24) 0 1px, transparent 1px 42px),
+    linear-gradient(135deg, rgba(255,255,255,0.32), rgba(181,18,24,0.24) 38%, rgba(238,231,216,0.06));
+}
+
+.industrial-atmosphere-light {
+  position: absolute;
+  z-index: 3;
+  display: block;
+  width: 0.18rem;
+  height: 16rem;
+  background: linear-gradient(180deg, transparent, #ff252b 16%, #ff252b 76%, transparent);
+  box-shadow: 0 0 22px rgba(255,37,43,0.8), 0 0 80px rgba(181,18,24,0.52);
+}
+
+.industrial-atmosphere-light-a {
+  right: 13.4%;
+  top: 21%;
+}
+
+.industrial-atmosphere-light-b {
+  left: 45%;
+  bottom: 8%;
+  height: 24rem;
+  transform: translateX(-50%);
+  opacity: 0;
+}
+
+.industrial-atmosphere-cables {
+  position: absolute;
+  z-index: 3;
+  left: 14%;
+  top: -4%;
+  width: 78%;
+  height: 42%;
+  background:
+    radial-gradient(ellipse at 18% 0%, transparent 0 46%, rgba(0,0,0,0.95) 47% 48%, transparent 49%),
+    radial-gradient(ellipse at 42% 0%, transparent 0 54%, rgba(0,0,0,0.9) 55% 56%, transparent 57%),
+    radial-gradient(ellipse at 70% 0%, transparent 0 48%, rgba(0,0,0,0.92) 49% 50%, transparent 51%),
+    repeating-linear-gradient(104deg, transparent 0 5rem, rgba(0,0,0,0.85) 5.05rem 5.18rem, transparent 5.24rem 9rem);
+  opacity: 0.72;
+}
+
+.industrial-atmosphere-floor {
+  position: absolute;
+  z-index: 1;
+  left: 34%;
+  right: 3%;
+  bottom: -8%;
+  height: 48%;
+  background:
+    repeating-linear-gradient(90deg, rgba(238,231,216,0.14) 0 1px, transparent 1px 4.8rem),
+    repeating-linear-gradient(0deg, rgba(238,231,216,0.09) 0 1px, transparent 1px 3rem),
+    linear-gradient(180deg, transparent, rgba(238,231,216,0.16));
+  transform: perspective(760px) rotateX(66deg);
+  transform-origin: bottom;
+  opacity: 0.76;
+}
+
+.industrial-home[data-active-section="work"] .industrial-atmosphere-screen-left,
+.industrial-home[data-active-section="work"] .industrial-atmosphere-screen-right,
+.industrial-home[data-active-section="systems"] .industrial-atmosphere-screen-left,
+.industrial-home[data-active-section="systems"] .industrial-atmosphere-screen-right {
+  opacity: 0.24;
+}
+
+.industrial-home[data-active-section="contact"] .industrial-atmosphere-light-a {
+  opacity: 0.22;
+}
+
+.industrial-home[data-active-section="contact"] .industrial-atmosphere-light-b {
+  opacity: 1;
 }
 
 .industrial-stage-illustration {
@@ -256,7 +402,7 @@ html {
 
 .industrial-hero-copy h1 {
   max-width: 8ch;
-  font-size: clamp(4.8rem, 15vw, 12rem);
+  font-size: clamp(4.8rem, 12vw, 9.8rem);
   text-shadow: 0 0 18px rgba(255,255,255,0.12);
 }
 
@@ -339,11 +485,36 @@ html {
 .industrial-section-rail span {
   position: relative;
   padding-left: 0.35rem;
+  transition: color 180ms ease, text-shadow 180ms ease;
+}
+
+.industrial-section-rail span::before {
+  content: "";
+  position: absolute;
+  left: calc(50% - 0.55rem);
+  top: 50%;
+  width: 0.28rem;
+  height: 0.28rem;
+  border-radius: 999px;
+  background: rgba(232,225,210,0.34);
+  transform: translate(-50%, -50%);
+  box-shadow: 0 0 0 rgba(181,18,24,0);
+  transition: background 180ms ease, box-shadow 180ms ease;
+}
+
+.industrial-section-rail span.is-active {
+  color: #fff8ea;
+  text-shadow: 0 0 18px rgba(181,18,24,0.85);
+}
+
+.industrial-section-rail span.is-active::before {
+  background: #ff252b;
+  box-shadow: 0 0 18px rgba(255,37,43,0.95);
 }
 
 .industrial-story-section {
   display: grid;
-  grid-template-columns: minmax(13rem, 0.72fr) minmax(0, 1.6fr);
+  grid-template-columns: minmax(13rem, 0.62fr) minmax(0, 1.78fr);
   align-items: center;
   gap: clamp(2rem, 6vw, 6rem);
 }
@@ -386,8 +557,9 @@ html {
 
 .industrial-project-list {
   display: grid;
-  grid-template-columns: repeat(4, minmax(10rem, 1fr));
+  grid-template-columns: minmax(13rem, 1.35fr) repeat(3, minmax(8.5rem, 1fr));
   gap: 1rem;
+  perspective: 1200px;
 }
 
 .industrial-project-slab,
@@ -404,12 +576,59 @@ html {
 }
 
 .industrial-project-slab {
+  position: relative;
   display: flex;
-  min-height: 23rem;
+  min-height: 26rem;
   flex-direction: column;
   justify-content: space-between;
   padding: 1rem;
   color: #eee7d8;
+  overflow: hidden;
+  transform: rotateY(-8deg) translateY(0);
+  transform-style: preserve-3d;
+}
+
+.industrial-project-slab:nth-child(1) {
+  transform: rotateY(-11deg) translateY(1rem);
+}
+
+.industrial-project-slab:nth-child(2) {
+  transform: rotateY(-6deg) translateY(-0.5rem);
+}
+
+.industrial-project-slab:nth-child(3) {
+  transform: rotateY(-4deg) translateY(0.7rem);
+}
+
+.industrial-project-slab:nth-child(4) {
+  transform: rotateY(-3deg) translateY(1.6rem);
+}
+
+.industrial-project-slab::before {
+  content: "";
+  position: absolute;
+  inset: 0.7rem;
+  border: 1px solid rgba(238,231,216,0.13);
+  background:
+    repeating-linear-gradient(0deg, rgba(238,231,216,0.035) 0 1px, transparent 1px 5px),
+    radial-gradient(circle at 22% 16%, rgba(238,231,216,0.12), transparent 8rem);
+  opacity: 0.72;
+}
+
+.industrial-project-slab::after {
+  content: "";
+  position: absolute;
+  top: -2rem;
+  left: 50%;
+  width: 1px;
+  height: 3.7rem;
+  background: linear-gradient(#eee7d8, rgba(238,231,216,0));
+  opacity: 0.3;
+}
+
+.industrial-project-slab > * {
+  position: relative;
+  z-index: 1;
 }
 
 .industrial-project-slab span {
@@ -422,8 +641,10 @@ html {
   margin-top: auto;
   color: #f5efe3;
   text-transform: uppercase;
-  font-size: clamp(1.4rem, 2.6vw, 2.25rem);
+  font-size: clamp(1.15rem, 1.9vw, 1.92rem);
   line-height: 1.05;
+  overflow-wrap: normal;
+  word-break: normal;
 }
 
 .industrial-project-slab p {
@@ -431,17 +652,87 @@ html {
   color: #b9b0a2;
   font-size: 0.82rem;
   line-height: 1.55;
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 10;
 }
 
 .industrial-capability-grid {
+  position: relative;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: clamp(1rem, 4vw, 3rem);
 }
 
+.industrial-capability-grid::before {
+  content: "";
+  position: absolute;
+  inset: 8% 12%;
+  border: 1px solid rgba(181,18,24,0.22);
+  background:
+    linear-gradient(30deg, transparent 49.6%, rgba(238,231,216,0.16) 50%, transparent 50.4%),
+    linear-gradient(150deg, transparent 49.6%, rgba(238,231,216,0.12) 50%, transparent 50.4%),
+    radial-gradient(circle at 50% 50%, rgba(181,18,24,0.3), transparent 2.4rem);
+  opacity: 0.6;
+}
+
 .industrial-capability-panel {
+  position: relative;
   min-height: 12rem;
   padding: clamp(1rem, 3vw, 1.6rem);
+}
+
+.industrial-capability-panel::before {
+  content: "";
+  position: absolute;
+  top: 0.7rem;
+  right: 0.7rem;
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: 999px;
+  background: #b51218;
+  box-shadow: 0 0 18px rgba(181,18,24,0.8);
+}
+
+.industrial-waveform {
+  display: flex;
+  align-items: center;
+  gap: 0.22rem;
+  width: min(14rem, 100%);
+  height: 5rem;
+  margin-top: 1.8rem;
+  opacity: 0.62;
+}
+
+.industrial-waveform span {
+  display: block;
+  width: 1px;
+  height: calc(0.45rem + (var(--bar-height, 1) * 0.34rem));
+  background: rgba(238,231,216,0.64);
+}
+
+.industrial-waveform span:nth-child(3n) {
+  --bar-height: 7;
+}
+
+.industrial-waveform span:nth-child(4n) {
+  --bar-height: 10;
+  background: rgba(181,18,24,0.82);
+}
+
+.industrial-waveform span:nth-child(5n) {
+  --bar-height: 4;
+}
+
+.industrial-node-readout {
+  display: grid;
+  width: 7rem;
+  gap: 0.22rem;
+  margin-top: 1.8rem;
+  color: rgba(238,231,216,0.38);
+  font-size: 0.58rem;
+  letter-spacing: 0.16em;
 }
 
 .industrial-capability-panel h3,
@@ -460,7 +751,7 @@ html {
 }
 
 .industrial-contact-section {
-  grid-template-columns: minmax(16rem, 0.86fr) minmax(18rem, 0.8fr);
+  grid-template-columns: minmax(16rem, 0.86fr) minmax(20rem, 0.95fr);
 }
 
 .industrial-writing-list {
@@ -480,10 +771,14 @@ html {
 
 .industrial-contact-panel {
   margin-left: auto;
-  max-width: 26rem;
+  max-width: 34rem;
   padding: clamp(1.25rem, 3vw, 2rem);
   border-left: 1px solid rgba(232, 225, 210, 0.22);
   background: rgba(4, 4, 4, 0.5);
+}
+
+.industrial-contact-panel h2 {
+  font-size: clamp(2.9rem, 5.2vw, 4.75rem);
 }
 
 .industrial-contact-panel dl {
@@ -616,6 +911,14 @@ html {
     grid-template-columns: 1fr 1fr;
   }
 
+  .industrial-project-slab,
+  .industrial-project-slab:nth-child(1),
+  .industrial-project-slab:nth-child(2),
+  .industrial-project-slab:nth-child(3),
+  .industrial-project-slab:nth-child(4) {
+    transform: none;
+  }
+
   .industrial-section-rail {
     display: none;
   }
@@ -632,6 +935,23 @@ html {
 
   .industrial-hero-copy h1 {
     font-size: clamp(3.4rem, 18.5vw, 4.8rem);
+  }
+
+  .industrial-atmosphere-screen-left {
+    display: none;
+  }
+
+  .industrial-atmosphere-screen-right {
+    right: -18%;
+    top: 22%;
+    width: 58vw;
+    opacity: 0.18;
+  }
+
+  .industrial-atmosphere-floor {
+    left: 4%;
+    right: -20%;
+    opacity: 0.28;
   }
 
   .industrial-hero-copy {
@@ -660,6 +980,10 @@ html {
     min-height: 17rem;
   }
 
+  .industrial-capability-grid::before {
+    display: none;
+  }
+
   .industrial-contact-panel {
     margin-left: 0;
     border-left: 0;
@@ -684,8 +1008,8 @@ html {
 
 .bg-grid-pattern {
   background-image:
-    linear-gradient(to right, rgba(0, 255, 140, 0.1) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(0, 255, 140, 0.1) 1px, transparent 1px);
+    linear-gradient(to right, rgba(181, 18, 24, 0.12) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(238, 231, 216, 0.06) 1px, transparent 1px);
   background-size: 20px 20px;
 }
 
@@ -708,12 +1032,12 @@ html {
 }
 
 .glitch::before {
-  color: #00ff8c;
+  color: #b51218;
   z-index: -1;
 }
 
 .glitch::after {
-  color: #ff00ff;
+  color: #b88556;
   z-index: -2;
 }
 
@@ -765,14 +1089,14 @@ html {
   display: inline-block;
   width: 10px;
   height: 1.2em;
-  background-color: #00ff8c;
+  background-color: #b51218;
   animation: blink 1s step-end infinite;
   vertical-align: text-bottom;
   margin-left: 2px;
 }
 
 .terminal-window {
-  border: 1px solid rgba(0, 255, 140, 0.5);
+  border: 1px solid rgba(181, 18, 24, 0.5);
   background-color: rgba(0, 0, 0, 0.8);
   border-radius: 4px;
   padding: 1rem;
@@ -784,7 +1108,7 @@ html {
   align-items: center;
   margin-bottom: 0.5rem;
   padding-bottom: 0.5rem;
-  border-bottom: 1px solid rgba(0, 255, 140, 0.3);
+  border-bottom: 1px solid rgba(238, 231, 216, 0.18);
 }
 
 .terminal-button {
@@ -835,18 +1159,18 @@ html {
 /* Card styling */
 .card-hover {
   transition: all 0.3s ease;
-  border: 1px solid rgba(0, 255, 140, 0.2);
+  border: 1px solid rgba(238, 231, 216, 0.16);
 }
 
 .card-hover:hover {
   transform: translateY(-5px);
-  box-shadow: 0 10px 20px rgba(0, 255, 140, 0.2);
-  border: 1px solid rgba(0, 255, 140, 0.6);
+  box-shadow: 0 10px 20px rgba(181, 18, 24, 0.2);
+  border: 1px solid rgba(181, 18, 24, 0.6);
 }
 
 .command-prompt::before {
   content: "$ ";
-  color: #00ff8c;
+  color: #b51218;
 }
 
 @layer utilities {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,10 +2,12 @@
 
 import dynamic from "next/dynamic"
 import Link from "next/link"
+import { useEffect, useMemo, useState } from "react"
 import {
   featuredPortfolioProjects,
   portfolioCapabilities,
   portfolioWriting,
+  type SceneSection,
   sceneSections,
 } from "@/data/portfolio"
 import { ArrowRight } from "lucide-react"
@@ -18,13 +20,56 @@ const IndustrialHomeExperience = dynamic(
   },
 )
 
+const waveformBars = Array.from({ length: 22 }, (_, index) => index)
+const nodeReadoutValues = ["-10", "-12", "-09", "-13", "-08", "-11"]
+
+function useActiveSceneSection(sections: SceneSection[]) {
+  const [progress, setProgress] = useState(0)
+
+  useEffect(() => {
+    let frame = 0
+    const update = () => {
+      cancelAnimationFrame(frame)
+      frame = requestAnimationFrame(() => {
+        const max = Math.max(document.documentElement.scrollHeight - window.innerHeight, 1)
+        setProgress(Math.min(window.scrollY / max, 1))
+      })
+    }
+
+    update()
+    window.addEventListener("scroll", update, { passive: true })
+    window.addEventListener("resize", update)
+    return () => {
+      cancelAnimationFrame(frame)
+      window.removeEventListener("scroll", update)
+      window.removeEventListener("resize", update)
+    }
+  }, [])
+
+  return useMemo(() => {
+    return sections.find((section) => progress >= section.range[0] && progress <= section.range[1]) ?? sections[0]
+  }, [progress, sections])
+}
+
 export default function Home() {
+  const activeSection = useActiveSceneSection(sceneSections)
+
   return (
-    <div className="industrial-home">
+    <div className="industrial-home" data-active-section={activeSection.id}>
       <IndustrialHomeExperience />
+      <div className="industrial-atmosphere" aria-hidden="true">
+        <span className="industrial-atmosphere-screen industrial-atmosphere-screen-left" />
+        <span className="industrial-atmosphere-screen industrial-atmosphere-screen-right" />
+        <span className="industrial-atmosphere-light industrial-atmosphere-light-a" />
+        <span className="industrial-atmosphere-light industrial-atmosphere-light-b" />
+        <span className="industrial-atmosphere-cables" />
+        <span className="industrial-atmosphere-floor" />
+      </div>
       <aside className="industrial-section-rail" aria-hidden="true">
         {sceneSections.map((section) => (
-          <span key={section.id}>{section.index}</span>
+          <span key={section.id} className={section.id === activeSection.id ? "is-active" : undefined}>
+            {section.index}
+          </span>
         ))}
       </aside>
 
@@ -49,6 +94,11 @@ export default function Home() {
           <span className="industrial-index">02</span>
           <h2>Selected Work</h2>
           <p>Scroll through projects where AI systems, spatial interfaces, and product execution meet real operating constraints.</p>
+          <div className="industrial-waveform" aria-hidden="true">
+            {waveformBars.map((index) => (
+              <span key={index} />
+            ))}
+          </div>
           <Link href="/projects" className="industrial-text-link">
             View all projects <ArrowRight size={14} />
           </Link>
@@ -69,6 +119,11 @@ export default function Home() {
           <span className="industrial-index">03</span>
           <h2>Systems I Build</h2>
           <p>Capabilities and systems thinking that power the work.</p>
+          <div className="industrial-node-readout" aria-hidden="true">
+            {nodeReadoutValues.map((value) => (
+              <span key={value}>{value}</span>
+            ))}
+          </div>
         </div>
         <div className="industrial-capability-grid">
           {portfolioCapabilities.map((capability) => (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,40 +23,71 @@ const IndustrialHomeExperience = dynamic(
 const waveformBars = Array.from({ length: 22 }, (_, index) => index)
 const nodeReadoutValues = ["-10", "-12", "-09", "-13", "-08", "-11"]
 
-function useActiveSceneSection(sections: SceneSection[]) {
+function useHomeScrollProgress() {
   const [progress, setProgress] = useState(0)
+  const [reducedMotion, setReducedMotion] = useState(false)
 
   useEffect(() => {
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)")
+    const updateMotion = () => setReducedMotion(media.matches)
+
+    updateMotion()
+    media.addEventListener("change", updateMotion)
+    return () => media.removeEventListener("change", updateMotion)
+  }, [])
+
+  useEffect(() => {
+    if (reducedMotion) {
+      setProgress(0)
+      return
+    }
+
     let frame = 0
+    let maxScroll = 1
+
+    const updateMaxScroll = () => {
+      maxScroll = Math.max(document.documentElement.scrollHeight - window.innerHeight, 1)
+    }
+
     const update = () => {
       cancelAnimationFrame(frame)
       frame = requestAnimationFrame(() => {
-        const max = Math.max(document.documentElement.scrollHeight - window.innerHeight, 1)
-        setProgress(Math.min(window.scrollY / max, 1))
+        setProgress(Math.min(window.scrollY / maxScroll, 1))
       })
     }
 
+    const handleResize = () => {
+      updateMaxScroll()
+      update()
+    }
+
+    updateMaxScroll()
     update()
     window.addEventListener("scroll", update, { passive: true })
-    window.addEventListener("resize", update)
+    window.addEventListener("resize", handleResize)
     return () => {
       cancelAnimationFrame(frame)
       window.removeEventListener("scroll", update)
-      window.removeEventListener("resize", update)
+      window.removeEventListener("resize", handleResize)
     }
-  }, [])
+  }, [reducedMotion])
 
+  return { progress, reducedMotion }
+}
+
+function useActiveSceneSection(sections: SceneSection[], progress: number) {
   return useMemo(() => {
     return sections.find((section) => progress >= section.range[0] && progress <= section.range[1]) ?? sections[0]
   }, [progress, sections])
 }
 
 export default function Home() {
-  const activeSection = useActiveSceneSection(sceneSections)
+  const { progress, reducedMotion } = useHomeScrollProgress()
+  const activeSection = useActiveSceneSection(sceneSections, progress)
 
   return (
     <div className="industrial-home" data-active-section={activeSection.id}>
-      <IndustrialHomeExperience />
+      <IndustrialHomeExperience progress={progress} reducedMotion={reducedMotion} />
       <div className="industrial-atmosphere" aria-hidden="true">
         <span className="industrial-atmosphere-screen industrial-atmosphere-screen-left" />
         <span className="industrial-atmosphere-screen industrial-atmosphere-screen-right" />

--- a/components/industrial-home-experience.tsx
+++ b/components/industrial-home-experience.tsx
@@ -5,6 +5,28 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import * as THREE from "three"
 import { featuredPortfolioProjects, portfolioCapabilities } from "@/data/portfolio"
 
+const tunnelRings = Array.from({ length: 18 }, (_, index) => index)
+const stageRails = Array.from({ length: 14 }, (_, index) => index)
+const towerPositions = [
+  [-6.8, 1.6, -4],
+  [6.6, 2.2, -6],
+  [7.4, 3.4, -13],
+  [-7.2, 2.8, -15],
+] as const
+const cableRuns = [
+  [-4.8, 5.1, 5, -0.52, 0.18, 0.08, 22],
+  [-2.5, 5.8, 3, -0.36, -0.12, -0.06, 24],
+  [1.6, 5.5, 4, -0.22, 0.22, 0.03, 26],
+  [4.7, 5.2, 2, -0.42, -0.18, -0.08, 23],
+] as const
+const floorLightPositions = Array.from({ length: 12 }, (_, index) => index)
+const smokePlumes = [
+  [-3.6, -0.65, -4, 1.2],
+  [3.5, -0.72, -7, 1.5],
+  [-2.2, -0.7, -14, 1.35],
+  [4.8, -0.7, -18, 1.1],
+] as const
+
 function useScrollProgress() {
   const [progress, setProgress] = useState(0)
   const [reducedMotion, setReducedMotion] = useState(false)
@@ -73,11 +95,15 @@ function IndustrialScene({ progress, reducedMotion }: { progress: number; reduce
       <pointLight position={[-7, 2, 3]} intensity={8} color={red} distance={20} />
       <pointLight position={[8, 3, -8]} intensity={5} color={amber} distance={24} />
       <group ref={groupRef}>
+        <OverheadCables />
         <Tunnel />
         <StageArchitecture />
+        <IndustrialSideScreens />
         <ProjectSlabs />
         <CapabilityField />
         <ContactBeacon />
+        <FloorRunway />
+        <SmokeLayer />
         <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -1.25, -5]}>
           <planeGeometry args={[42, 80, 20, 20]} />
           <meshStandardMaterial color={steel} roughness={0.82} metalness={0.7} />
@@ -88,11 +114,9 @@ function IndustrialScene({ progress, reducedMotion }: { progress: number; reduce
 }
 
 function Tunnel() {
-  const rings = Array.from({ length: 16 }, (_, index) => index)
-
   return (
     <group position={[0, 0, 0]}>
-      {rings.map((index) => (
+      {tunnelRings.map((index) => (
         <group key={index}>
           <mesh position={[0, 0, -index * 1.85]} rotation={[Math.PI / 2, 0, 0]}>
             <torusGeometry args={[4.8 + index * 0.03, 0.035, 8, 72]} />
@@ -127,25 +151,23 @@ function Tunnel() {
 }
 
 function StageArchitecture() {
-  const rails = Array.from({ length: 12 }, (_, index) => index)
-
   return (
     <group>
-      {rails.map((index) => (
+      {stageRails.map((index) => (
         <mesh key={`rail-${index}`} position={[0, -1.03, -index * 2.6]} rotation={[0, 0, 0]}>
           <boxGeometry args={[9.5, 0.018, 0.018]} />
           <meshBasicMaterial color={index % 2 === 0 ? "#8a7d6e" : "#3b332e"} />
         </mesh>
       ))}
       {[-5.8, 5.8].map((x) =>
-        rails.map((index) => (
+        stageRails.map((index) => (
           <mesh key={`walk-${x}-${index}`} position={[x, -0.75, -index * 2.4]}>
             <boxGeometry args={[0.05, 1.8, 0.05]} />
             <meshStandardMaterial color="#2d2924" emissive="#120d0c" emissiveIntensity={0.18} metalness={0.85} roughness={0.48} />
           </mesh>
         )),
       )}
-      {[[-6.8, 1.6, -4], [6.6, 2.2, -6], [7.4, 3.4, -13], [-7.2, 2.8, -15]].map(([x, y, z], index) => (
+      {towerPositions.map(([x, y, z], index) => (
         <group key={`tower-${index}`} position={[x, y, z]}>
           <mesh>
             <boxGeometry args={[0.16, 4.8, 0.16]} />
@@ -170,6 +192,77 @@ function StageArchitecture() {
         <boxGeometry args={[1.8, 1.8, 0.08]} />
         <meshBasicMaterial color="#5b1013" />
       </mesh>
+    </group>
+  )
+}
+
+function OverheadCables() {
+  return (
+    <group>
+      {cableRuns.map(([x, y, z, rotX, rotY, rotZ, length], index) => (
+        <mesh key={`cable-${index}`} position={[x, y, z]} rotation={[rotX, rotY, rotZ]}>
+          <boxGeometry args={[0.035, 0.035, length]} />
+          <meshStandardMaterial color="#070707" metalness={0.55} roughness={0.8} />
+        </mesh>
+      ))}
+    </group>
+  )
+}
+
+function IndustrialSideScreens() {
+  return (
+    <group>
+      {[
+        [-4.9, 1.5, -4.8, 0.36],
+        [6.1, 1.8, -7.5, -0.45],
+      ].map(([x, y, z, rotationY], index) => (
+        <group key={`screen-${index}`} position={[x, y, z]} rotation={[0, rotationY, 0]}>
+          <mesh>
+            <boxGeometry args={[3.4, 1.9, 0.09]} />
+            <meshStandardMaterial color="#080807" emissive="#111111" emissiveIntensity={0.9} metalness={0.55} roughness={0.48} />
+          </mesh>
+          <mesh position={[0, 0, 0.058]}>
+            <planeGeometry args={[3.05, 1.55]} />
+            <meshBasicMaterial color={index === 0 ? "#f1ede3" : "#8d1115"} transparent opacity={index === 0 ? 0.28 : 0.24} />
+          </mesh>
+          {Array.from({ length: 7 }, (_, line) => (
+            <mesh key={`screen-line-${index}-${line}`} position={[0, -0.58 + line * 0.18, 0.07]}>
+              <boxGeometry args={[2.62 - (line % 3) * 0.42, 0.012, 0.01]} />
+              <meshBasicMaterial color={index === 0 ? "#eee7d8" : "#ff2028"} transparent opacity={0.36} />
+            </mesh>
+          ))}
+        </group>
+      ))}
+    </group>
+  )
+}
+
+function FloorRunway() {
+  return (
+    <group position={[0, -1.16, -9]}>
+      {floorLightPositions.map((index) => (
+        <mesh key={`floor-light-${index}`} position={[(index % 2 === 0 ? -1 : 1) * 1.72, 0.05, 4 - index * 2.2]}>
+          <boxGeometry args={[0.62, 0.018, 0.035]} />
+          <meshBasicMaterial color={index % 3 === 0 ? "#e6ded0" : "#b51218"} transparent opacity={0.62} />
+        </mesh>
+      ))}
+      <mesh position={[0, 0.02, -8]} rotation={[-Math.PI / 2, 0, 0]}>
+        <ringGeometry args={[0.7, 1.9, 48]} />
+        <meshBasicMaterial color="#b51218" transparent opacity={0.22} side={THREE.DoubleSide} />
+      </mesh>
+    </group>
+  )
+}
+
+function SmokeLayer() {
+  return (
+    <group>
+      {smokePlumes.map(([x, y, z, scale], index) => (
+        <mesh key={`smoke-${index}`} position={[x, y, z]} rotation={[0, 0, index * 0.3]}>
+          <planeGeometry args={[3.2 * scale, 1.1 * scale]} />
+          <meshBasicMaterial color="#d7d0c4" transparent opacity={0.055} depthWrite={false} side={THREE.DoubleSide} />
+        </mesh>
+      ))}
     </group>
   )
 }

--- a/components/industrial-home-experience.tsx
+++ b/components/industrial-home-experience.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Canvas, useFrame } from "@react-three/fiber"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useMemo, useRef } from "react"
 import * as THREE from "three"
 import { featuredPortfolioProjects, portfolioCapabilities } from "@/data/portfolio"
 
@@ -27,44 +27,9 @@ const smokePlumes = [
   [4.8, -0.7, -18, 1.1],
 ] as const
 
-function useScrollProgress() {
-  const [progress, setProgress] = useState(0)
-  const [reducedMotion, setReducedMotion] = useState(false)
-
-  useEffect(() => {
-    const media = window.matchMedia("(prefers-reduced-motion: reduce)")
-    const updateMotion = () => setReducedMotion(media.matches)
-    updateMotion()
-    media.addEventListener("change", updateMotion)
-    return () => media.removeEventListener("change", updateMotion)
-  }, [])
-
-  useEffect(() => {
-    if (reducedMotion) {
-      setProgress(0)
-      return
-    }
-
-    let frame = 0
-    const update = () => {
-      cancelAnimationFrame(frame)
-      frame = requestAnimationFrame(() => {
-        const max = Math.max(document.documentElement.scrollHeight - window.innerHeight, 1)
-        setProgress(Math.min(window.scrollY / max, 1))
-      })
-    }
-
-    update()
-    window.addEventListener("scroll", update, { passive: true })
-    window.addEventListener("resize", update)
-    return () => {
-      cancelAnimationFrame(frame)
-      window.removeEventListener("scroll", update)
-      window.removeEventListener("resize", update)
-    }
-  }, [reducedMotion])
-
-  return { progress, reducedMotion }
+type IndustrialHomeExperienceProps = {
+  progress: number
+  reducedMotion: boolean
 }
 
 function lerp(start: number, end: number, progress: number) {
@@ -331,9 +296,7 @@ function ContactBeacon() {
   )
 }
 
-export function IndustrialHomeExperience() {
-  const { progress, reducedMotion } = useScrollProgress()
-
+export function IndustrialHomeExperience({ progress, reducedMotion }: IndustrialHomeExperienceProps) {
   return (
     <div className="industrial-canvas" aria-hidden="true">
       <Canvas


### PR DESCRIPTION
## Summary
- add a richer fixed industrial atmosphere layer with side screens, cables, floor geometry, and beacon lighting
- add scroll-aware active section state and active rail markers on the immersive homepage
- deepen the 3D scene with overhead cables, side screens, floor lights, smoke, and static geometry arrays
- tune project slabs, systems cards, contact layout, and remaining legacy green utility accents toward the industrial visual system

## Validation
- pnpm lint
- pnpm type-check
- pnpm test:unit
- pnpm build
- Playwright CLI screenshots on production server for desktop hero, work beat, and mobile hero

## Notes
- Local production QA shows one expected local-only 404 for /_vercel/insights/script.js because Vercel Insights is not served by next start.