### PR TITLE
Deepen industrial 3D portfolio scene

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -167,7 +167,59 @@ html {
 }
 
 .industrial-canvas canvas {
+  opacity: 0;
+  transition: opacity 480ms ease;
+}
+
+.industrial-canvas.is-ready canvas {
   opacity: 0.98;
+}
+
+.industrial-canvas.is-low-power canvas {
+  opacity: 0.92;
+}
+
+.industrial-canvas-loader {
+  position: absolute;
+  left: clamp(1.5rem, 6vw, 5rem);
+  bottom: clamp(1.25rem, 8vh, 5rem);
+  z-index: 5;
+  display: grid;
+  width: min(16rem, calc(100vw - 3rem));
+  gap: 0.7rem;
+  color: rgba(238,231,216,0.72);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.62rem;
+  pointer-events: none;
+  transition: opacity 220ms ease;
+}
+
+.industrial-canvas-loader i {
+  display: block;
+  width: 100%;
+  height: 1px;
+  overflow: hidden;
+  background: rgba(238,231,216,0.16);
+}
+
+.industrial-canvas-loader i::before {
+  content: "";
+  display: block;
+  width: 42%;
+  height: 100%;
+  background: linear-gradient(90deg, rgba(181,18,24,0), rgba(238,231,216,0.92), rgba(181,18,24,0.72));
+  animation: industrial-loader-scan 1.1s ease-in-out infinite;
+}
+
+@keyframes industrial-loader-scan {
+  0% {
+    transform: translateX(-105%);
+  }
+
+  100% {
+    transform: translateX(245%);
+  }
 }
 
 .industrial-atmosphere {
@@ -190,10 +242,10 @@ html {
   inset: 0;
   z-index: 0;
   background:
-    linear-gradient(90deg, rgba(0,0,0,0.98) 0 8%, rgba(0,0,0,0.72) 28%, transparent 48%, rgba(0,0,0,0.36) 74%, rgba(0,0,0,0.58) 100%),
-    radial-gradient(circle at 52% 31%, rgba(239,231,216,0.36), transparent 13rem),
-    radial-gradient(circle at 79% 35%, rgba(181,18,24,0.36), transparent 14rem),
-    radial-gradient(ellipse at 62% 78%, rgba(238,231,216,0.15), transparent 22rem),
+    linear-gradient(90deg, rgba(0,0,0,0.98) 0 8%, rgba(0,0,0,0.76) 26%, transparent 50%, rgba(0,0,0,0.42) 76%, rgba(0,0,0,0.66) 100%),
+    radial-gradient(circle at 52% 31%, rgba(239,231,216,0.16), transparent 11rem),
+    radial-gradient(circle at 79% 35%, rgba(181,18,24,0.24), transparent 13rem),
+    radial-gradient(ellipse at 62% 78%, rgba(238,231,216,0.11), transparent 20rem),
     linear-gradient(180deg, transparent 0 57%, rgba(0,0,0,0.65) 82%, #030303 100%);
 }
 
@@ -222,7 +274,7 @@ html {
   box-shadow:
     inset 0 0 54px rgba(0,0,0,0.76),
     0 0 70px rgba(238,231,216,0.2);
-  opacity: 0.48;
+  opacity: 0.32;
   mix-blend-mode: screen;
 }
 
@@ -296,7 +348,56 @@ html {
     linear-gradient(180deg, transparent, rgba(238,231,216,0.16));
   transform: perspective(760px) rotateX(66deg);
   transform-origin: bottom;
-  opacity: 0.76;
+  opacity: 0.58;
+}
+
+.industrial-atmosphere-gantry {
+  position: absolute;
+  z-index: 2;
+  display: block;
+  top: 10%;
+  bottom: 9%;
+  width: min(18vw, 16rem);
+  pointer-events: none;
+  background:
+    repeating-linear-gradient(90deg, rgba(238,231,216,0.11) 0 1px, transparent 1px 2.4rem),
+    repeating-linear-gradient(0deg, rgba(238,231,216,0.08) 0 1px, transparent 1px 3.1rem),
+    linear-gradient(110deg, transparent 0 46%, rgba(0,0,0,0.88) 47% 49%, transparent 50%),
+    linear-gradient(70deg, transparent 0 52%, rgba(0,0,0,0.78) 53% 55%, transparent 56%);
+  opacity: 0.62;
+  box-shadow: inset 0 0 90px rgba(0,0,0,0.9);
+}
+
+.industrial-atmosphere-gantry-left {
+  left: 0;
+  transform: perspective(780px) rotateY(28deg);
+  transform-origin: left center;
+  mask-image: linear-gradient(90deg, black 0 55%, transparent 100%);
+  opacity: 0.34;
+}
+
+.industrial-atmosphere-gantry-right {
+  right: 4%;
+  transform: perspective(820px) rotateY(-22deg);
+  transform-origin: right center;
+  mask-image: linear-gradient(90deg, transparent 0, black 42% 100%);
+}
+
+.industrial-atmosphere-smoke {
+  position: absolute;
+  z-index: 3;
+  left: -8%;
+  right: -8%;
+  bottom: -12%;
+  height: 34%;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse at 18% 72%, rgba(238,231,216,0.16), transparent 19rem),
+    radial-gradient(ellipse at 58% 66%, rgba(238,231,216,0.1), transparent 22rem),
+    radial-gradient(ellipse at 82% 78%, rgba(181,18,24,0.12), transparent 18rem),
+    linear-gradient(180deg, transparent, rgba(3,3,3,0.86) 82%);
+  filter: blur(10px);
+  opacity: 0.58;
 }
 
 .industrial-home[data-active-section="work"] .industrial-atmosphere-screen-left,
@@ -304,6 +405,11 @@ html {
 .industrial-home[data-active-section="systems"] .industrial-atmosphere-screen-left,
 .industrial-home[data-active-section="systems"] .industrial-atmosphere-screen-right {
   opacity: 0.24;
+}
+
+.industrial-home[data-active-section="work"] .industrial-atmosphere-gantry,
+.industrial-home[data-active-section="systems"] .industrial-atmosphere-gantry {
+  opacity: 0.16;
 }
 
 .industrial-home[data-active-section="contact"] .industrial-atmosphere-light-a {
@@ -320,12 +426,12 @@ html {
   pointer-events: none;
   background:
     linear-gradient(90deg, rgba(0,0,0,0.9) 0 16%, transparent 44%, rgba(0,0,0,0.72) 100%),
-    radial-gradient(circle at 56% 42%, rgba(232,225,210,0.18), transparent 7rem),
-    radial-gradient(circle at 78% 40%, rgba(181,18,24,0.24), transparent 14rem),
-    repeating-radial-gradient(ellipse at 57% 43%, rgba(232,225,210,0.2) 0 1px, transparent 1px 22px),
+    radial-gradient(circle at 56% 42%, rgba(232,225,210,0.13), transparent 7rem),
+    radial-gradient(circle at 78% 40%, rgba(181,18,24,0.2), transparent 14rem),
+    repeating-radial-gradient(ellipse at 57% 43%, rgba(232,225,210,0.16) 0 1px, transparent 1px 22px),
     linear-gradient(115deg, transparent 0 48%, rgba(232,225,210,0.18) 49%, transparent 50% 100%),
     linear-gradient(75deg, transparent 0 52%, rgba(232,225,210,0.12) 53%, transparent 54% 100%);
-  opacity: 0.54;
+  opacity: 0.26;
   mask-image: linear-gradient(90deg, transparent 0 42%, black 54% 100%);
 }
 
@@ -362,9 +468,37 @@ html {
 
 .industrial-canvas-fallback {
   background:
-    linear-gradient(90deg, rgba(181,18,24,0.12), transparent 34%),
-    radial-gradient(circle at 50% 45%, rgba(232,225,210,0.1), transparent 24rem),
+    linear-gradient(90deg, rgba(0,0,0,0.96) 0 18%, transparent 50%, rgba(0,0,0,0.78) 100%),
+    radial-gradient(circle at 57% 36%, rgba(232,225,210,0.2), transparent 9rem),
+    repeating-radial-gradient(ellipse at 58% 37%, rgba(232,225,210,0.18) 0 1px, transparent 1px 24px),
+    radial-gradient(circle at 80% 35%, rgba(181,18,24,0.24), transparent 15rem),
     #030303;
+}
+
+.industrial-fallback-stage {
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(90deg, transparent 0 5rem, rgba(238,231,216,0.08) 5.05rem 5.1rem, transparent 5.2rem 9rem),
+    repeating-linear-gradient(0deg, transparent 0 3.4rem, rgba(238,231,216,0.05) 3.45rem, transparent 3.55rem);
+  mask-image: linear-gradient(90deg, transparent 0 32%, black 48%, transparent 100%);
+  opacity: 0.72;
+}
+
+.industrial-canvas-unavailable::after {
+  content: "";
+  position: absolute;
+  right: 6%;
+  top: 22%;
+  width: min(28vw, 24rem);
+  height: min(28vh, 14rem);
+  border: 1px solid rgba(238,231,216,0.22);
+  background:
+    repeating-linear-gradient(0deg, rgba(238,231,216,0.26) 0 1px, transparent 1px 8px),
+    linear-gradient(135deg, rgba(255,255,255,0.18), rgba(181,18,24,0.18), transparent);
+  transform: perspective(760px) rotateY(-30deg);
+  opacity: 0.5;
+  box-shadow: inset 0 0 60px rgba(0,0,0,0.8), 0 0 80px rgba(181,18,24,0.16);
 }
 
 .industrial-home {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -74,7 +74,7 @@ function useHomeScrollProgress() {
   }, [reducedMotion])
 
   useEffect(() => {
-    const updateVisibility = () => setSceneActive(document.visibilityState === "visible")
+    const updateVisibility = () => setSceneActive(document.visibilityState === "visible" && document.hasFocus())
 
     updateVisibility()
     document.addEventListener("visibilitychange", updateVisibility)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,6 +26,7 @@ const nodeReadoutValues = ["-10", "-12", "-09", "-13", "-08", "-11"]
 function useHomeScrollProgress() {
   const [progress, setProgress] = useState(0)
   const [reducedMotion, setReducedMotion] = useState(false)
+  const [sceneActive, setSceneActive] = useState(true)
 
   useEffect(() => {
     const media = window.matchMedia("(prefers-reduced-motion: reduce)")
@@ -72,7 +73,22 @@ function useHomeScrollProgress() {
     }
   }, [reducedMotion])
 
-  return { progress, reducedMotion }
+  useEffect(() => {
+    const updateVisibility = () => setSceneActive(document.visibilityState === "visible")
+
+    updateVisibility()
+    document.addEventListener("visibilitychange", updateVisibility)
+    window.addEventListener("focus", updateVisibility)
+    window.addEventListener("blur", updateVisibility)
+
+    return () => {
+      document.removeEventListener("visibilitychange", updateVisibility)
+      window.removeEventListener("focus", updateVisibility)
+      window.removeEventListener("blur", updateVisibility)
+    }
+  }, [])
+
+  return { progress, reducedMotion, sceneActive }
 }
 
 function useActiveSceneSection(sections: SceneSection[], progress: number) {
@@ -82,12 +98,12 @@ function useActiveSceneSection(sections: SceneSection[], progress: number) {
 }
 
 export default function Home() {
-  const { progress, reducedMotion } = useHomeScrollProgress()
+  const { progress, reducedMotion, sceneActive } = useHomeScrollProgress()
   const activeSection = useActiveSceneSection(sceneSections, progress)
 
   return (
     <div className="industrial-home" data-active-section={activeSection.id}>
-      <IndustrialHomeExperience progress={progress} reducedMotion={reducedMotion} />
+      <IndustrialHomeExperience progress={progress} reducedMotion={reducedMotion} sceneActive={sceneActive} />
       <div className="industrial-atmosphere" aria-hidden="true">
         <span className="industrial-atmosphere-screen industrial-atmosphere-screen-left" />
         <span className="industrial-atmosphere-screen industrial-atmosphere-screen-right" />
@@ -95,6 +111,9 @@ export default function Home() {
         <span className="industrial-atmosphere-light industrial-atmosphere-light-b" />
         <span className="industrial-atmosphere-cables" />
         <span className="industrial-atmosphere-floor" />
+        <span className="industrial-atmosphere-gantry industrial-atmosphere-gantry-left" />
+        <span className="industrial-atmosphere-gantry industrial-atmosphere-gantry-right" />
+        <span className="industrial-atmosphere-smoke" />
       </div>
       <aside className="industrial-section-rail" aria-hidden="true">
         {sceneSections.map((section) => (

--- a/components/industrial-home-experience.tsx
+++ b/components/industrial-home-experience.tsx
@@ -1,14 +1,17 @@
 "use client"
 
 import { Canvas, useFrame } from "@react-three/fiber"
+import { AdaptiveDpr, PerformanceMonitor, Preload, Sparkles } from "@react-three/drei"
 import { Bloom, ChromaticAberration, EffectComposer, Noise, Scanline, Vignette } from "@react-three/postprocessing"
-import { useMemo, useRef } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import * as THREE from "three"
 import { BlendFunction } from "postprocessing"
 import { featuredPortfolioProjects, portfolioCapabilities } from "@/data/portfolio"
 
 const tunnelRings = Array.from({ length: 18 }, (_, index) => index)
+const lowPowerTunnelRings = tunnelRings.filter((index) => index < 16 && index % 2 === 0)
 const stageRails = Array.from({ length: 14 }, (_, index) => index)
+const lowPowerStageRails = stageRails.filter((index) => index % 2 === 0)
 const towerPositions = [
   [-6.8, 1.6, -4],
   [6.6, 2.2, -6],
@@ -29,13 +32,25 @@ const cableCurveSeeds = [
   [7.1, 4.4, -1, 3.2, 3.2, -12, 0.2, 3.9, -27],
 ] as const
 const floorLightPositions = Array.from({ length: 12 }, (_, index) => index)
+const lowPowerFloorLightPositions = floorLightPositions.filter((index) => index % 2 === 0)
 const runwayPlatePositions = Array.from({ length: 18 }, (_, index) => index)
+const lowPowerRunwayPlatePositions = runwayPlatePositions.filter((index) => index % 2 === 0)
 const screenLineIndices = Array.from({ length: 12 }, (_, index) => index)
 const tunnelStruts = Array.from({ length: 24 }, (_, index) => index)
+const lowPowerTunnelStruts = tunnelStruts.filter((index) => index % 2 === 0)
 const wallRibs = Array.from({ length: 14 }, (_, index) => index)
+const lowPowerWallRibs = wallRibs.filter((index) => index % 2 === 0)
 const scaffoldLevels = Array.from({ length: 6 }, (_, index) => index)
 const runwayGrates = Array.from({ length: 22 }, (_, index) => index)
+const lowPowerRunwayGrates = runwayGrates.filter((index) => index % 2 === 0)
 const rearSpokeIndices = Array.from({ length: 16 }, (_, index) => index)
+const lowPowerRearSpokeIndices = rearSpokeIndices.filter((index) => index % 2 === 0)
+const heroTowerRows = Array.from({ length: 9 }, (_, index) => index)
+const heroTrussRuns = Array.from({ length: 7 }, (_, index) => index)
+const heroLightStacks = Array.from({ length: 8 }, (_, index) => index)
+const foregroundRailPosts = Array.from({ length: 12 }, (_, index) => index)
+const lowPowerForegroundRailPosts = foregroundRailPosts.filter((index) => index % 2 === 0)
+const gantryLadderRungs = Array.from({ length: 10 }, (_, index) => index)
 const smokePlumes = [
   [-3.6, -0.65, -4, 1.2],
   [3.5, -0.72, -7, 1.5],
@@ -117,18 +132,50 @@ const screenVertexShader = `
 type IndustrialHomeExperienceProps = {
   progress: number
   reducedMotion: boolean
+  sceneActive: boolean
 }
 
 function lerp(start: number, end: number, progress: number) {
   return start + (end - start) * progress
 }
 
-function IndustrialScene({ progress, reducedMotion }: { progress: number; reducedMotion: boolean }) {
+function canUseWebGL() {
+  if (typeof window === "undefined") return false
+  try {
+    const canvas = document.createElement("canvas")
+    return Boolean(canvas.getContext("webgl2") ?? canvas.getContext("webgl") ?? canvas.getContext("experimental-webgl"))
+  } catch {
+    return false
+  }
+}
+
+function shouldStartLowPower() {
+  if (typeof window === "undefined") return false
+  const cores = window.navigator.hardwareConcurrency || 4
+  const coarsePointer = window.matchMedia("(pointer: coarse)").matches
+  const compactViewport = window.matchMedia("(max-width: 760px)").matches
+  return cores <= 4 || (coarsePointer && compactViewport)
+}
+
+function IndustrialScene({
+  lowPower,
+  onPerformanceDecline,
+  progress,
+  reducedMotion,
+  sceneActive,
+}: {
+  lowPower: boolean
+  onPerformanceDecline: () => void
+  progress: number
+  reducedMotion: boolean
+  sceneActive: boolean
+}) {
   const groupRef = useRef<THREE.Group>(null)
   const red = useMemo(() => new THREE.Color("#b51218"), [])
   const amber = useMemo(() => new THREE.Color("#b88556"), [])
 
   useFrame(({ camera, clock }) => {
+    if (!sceneActive) return
     const t = reducedMotion ? 0 : progress
     camera.position.set(lerp(0, 7, t), lerp(1.4, 4.6, t), lerp(18, -10, t))
     camera.rotation.set(lerp(-0.05, -0.2, t), lerp(0, -0.3, t), 0)
@@ -150,27 +197,156 @@ function IndustrialScene({ progress, reducedMotion }: { progress: number; reduce
         <CinematicLightVolume progress={progress} />
         <OverheadCables />
         <CableCurtain />
-        <Tunnel />
-        <RearTunnelCore progress={progress} />
-        <IndustrialWallScaffolds progress={progress} />
-        <StageArchitecture />
+        <IndustrialParticles lowPower={lowPower} />
+        <Tunnel lowPower={lowPower} />
+        <HeroSetPieces lowPower={lowPower} progress={progress} />
+        <ForegroundRunwayRig lowPower={lowPower} progress={progress} />
+        <RearTunnelCore lowPower={lowPower} progress={progress} />
+        <IndustrialWallScaffolds lowPower={lowPower} progress={progress} />
+        <StageArchitecture lowPower={lowPower} />
         <IndustrialSideScreens progress={progress} />
         <ProjectSlabs />
         <CapabilityField />
         <ContactBeacon />
-        <FloorRunway progress={progress} />
-        <SmokeLayer />
-        <ShaderFloor progress={progress} />
+        <FloorRunway lowPower={lowPower} progress={progress} />
+        <SmokeLayer lowPower={lowPower} />
+        <ShaderFloor lowPower={lowPower} progress={progress} />
       </group>
-      <CinematicEffects reducedMotion={reducedMotion} />
+      <PerformanceMonitor onDecline={onPerformanceDecline} onFallback={onPerformanceDecline} />
+      <AdaptiveDpr pixelated />
+      <Preload all />
+      <CinematicEffects lowPower={lowPower} reducedMotion={reducedMotion} />
     </>
   )
 }
 
-function Tunnel() {
+function IndustrialParticles({ lowPower }: { lowPower: boolean }) {
+  return (
+    <group visible={!lowPower}>
+      <Sparkles count={72} speed={0.18} opacity={0.42} color="#eee7d8" size={1.7} scale={[8.5, 3.2, 24]} position={[1.1, 1.15, -11]} />
+      <Sparkles count={28} speed={0.28} opacity={0.36} color="#b51218" size={2.2} scale={[7, 2.6, 20]} position={[3.2, 1.5, -13]} />
+    </group>
+  )
+}
+
+function HeroSetPieces({ lowPower, progress }: { lowPower: boolean; progress: number }) {
+  const activeRows = lowPower ? heroTowerRows.filter((index) => index % 2 === 0) : heroTowerRows
+  const activeTrusses = lowPower ? heroTrussRuns.filter((index) => index % 2 === 0) : heroTrussRuns
+
+  return (
+    <group>
+      {[-1, 1].map((side) => (
+        <group key={`hero-side-${side}`} position={[side * 5.85, 0.45, -5.2]} rotation={[0, side * -0.08, 0]}>
+          {activeRows.map((index) => (
+            <group key={`hero-rib-${side}-${index}`} position={[side * (0.12 + (index % 2) * 0.32), 0.15, -index * 1.95]}>
+              <mesh position={[0, 1.8, 0]}>
+                <boxGeometry args={[0.09, 4.8 + (index % 3) * 0.9, 0.08]} />
+                <meshStandardMaterial color="#12100e" emissive="#060303" emissiveIntensity={0.35} metalness={0.9} roughness={0.42} />
+              </mesh>
+              <mesh position={[side * -0.42, 3.82, -0.16]} rotation={[0, side * 0.12, side * 0.2]}>
+                <boxGeometry args={[1.35, 0.045, 0.055]} />
+                <meshStandardMaterial color="#2f2924" emissive="#0e0807" emissiveIntensity={0.26} metalness={0.9} roughness={0.38} />
+              </mesh>
+              <mesh position={[side * -0.2, 0.62, 0.18]}>
+                <boxGeometry args={[0.78, 0.18, 0.26]} />
+                <meshStandardMaterial color="#0b0a09" emissive={index % 4 === 0 ? "#210708" : "#030202"} emissiveIntensity={0.42 + progress * 0.2} metalness={0.72} roughness={0.55} />
+              </mesh>
+              {heroLightStacks.map((light) => (
+                <mesh key={`hero-light-${side}-${index}-${light}`} position={[side * -0.15, 0.85 + light * 0.34, 0.34]} visible={index % 3 === 0 && light < 5}>
+                  <boxGeometry args={[0.035, 0.12, 0.025]} />
+                  <meshBasicMaterial color={light % 2 === 0 ? "#ff252b" : "#b88556"} transparent opacity={0.72} />
+                </mesh>
+              ))}
+            </group>
+          ))}
+          <mesh position={[side * -0.55, -0.72, -7.4]} rotation={[-Math.PI / 2, 0, side * 0.03]}>
+            <boxGeometry args={[1.2, 18, 0.035]} />
+            <meshStandardMaterial color="#181512" emissive="#080404" emissiveIntensity={0.2} metalness={0.9} roughness={0.4} />
+          </mesh>
+        </group>
+      ))}
+      {activeTrusses.map((index) => (
+        <group key={`hero-truss-${index}`} position={[0.9, 4.45 - (index % 2) * 0.22, -2.4 - index * 2.7]} rotation={[0.05, 0, index % 2 === 0 ? 0.04 : -0.04]}>
+          <mesh>
+            <boxGeometry args={[10.8, 0.055, 0.055]} />
+            <meshStandardMaterial color="#090807" metalness={0.78} roughness={0.58} />
+          </mesh>
+          <mesh position={[0, -0.32, 0]} rotation={[0, 0, 0.18]}>
+            <boxGeometry args={[10.2, 0.028, 0.034]} />
+            <meshStandardMaterial color="#15110f" metalness={0.82} roughness={0.5} />
+          </mesh>
+        </group>
+      ))}
+      <mesh position={[1.35, -0.78, -8.8]} rotation={[-Math.PI / 2, 0, 0]}>
+        <boxGeometry args={[1.65, 22, 0.03]} />
+        <meshStandardMaterial color="#171411" emissive="#110606" emissiveIntensity={0.34} metalness={0.94} roughness={0.33} />
+      </mesh>
+      <mesh position={[1.35, -0.735, -8.8]} rotation={[-Math.PI / 2, 0, 0]}>
+        <planeGeometry args={[1.28, 20, 3, 28]} />
+        <meshBasicMaterial color="#82796b" transparent opacity={0.18} side={THREE.DoubleSide} />
+      </mesh>
+    </group>
+  )
+}
+
+function ForegroundRunwayRig({ lowPower, progress }: { lowPower: boolean; progress: number }) {
+  const activePosts = lowPower ? lowPowerForegroundRailPosts : foregroundRailPosts
+  const glowOpacity = 0.42 + progress * 0.18
+
+  return (
+    <group position={[0, -0.92, 0.4]}>
+      {[-1, 1].map((side) => (
+        <group key={`runway-rig-${side}`} position={[side * 3.05, 0, -5.2]} rotation={[0, side * -0.04, 0]}>
+          {activePosts.map((index) => (
+            <group key={`runway-post-${side}-${index}`} position={[side * (0.24 + (index % 2) * 0.12), 0.1, -index * 2.05]}>
+              <mesh position={[0, 0.62, 0]}>
+                <boxGeometry args={[0.045, 1.34, 0.045]} />
+                <meshStandardMaterial color="#171411" emissive="#060404" emissiveIntensity={0.18} metalness={0.88} roughness={0.46} />
+              </mesh>
+              <mesh position={[side * -0.28, 1.18, -0.2]} rotation={[0, side * 0.04, 0]}>
+                <boxGeometry args={[0.82, 0.035, 0.035]} />
+                <meshStandardMaterial color="#3d352e" emissive="#120c0b" emissiveIntensity={0.22} metalness={0.9} roughness={0.38} />
+              </mesh>
+              <mesh position={[side * -0.04, 1.42, 0.04]} visible={index % 3 === 0}>
+                <boxGeometry args={[0.05, 0.22, 0.05]} />
+                <meshBasicMaterial color="#ff252b" transparent opacity={glowOpacity} />
+              </mesh>
+              <pointLight position={[side * -0.04, 1.42, 0.2]} intensity={index % 3 === 0 ? 1.55 + progress : 0} color="#b51218" distance={3.2} />
+            </group>
+          ))}
+          <mesh position={[side * -0.1, 1.22, -11.4]}>
+            <boxGeometry args={[0.035, 0.035, 25.5]} />
+            <meshStandardMaterial color="#5b5045" emissive="#1a1110" emissiveIntensity={0.24} metalness={0.9} roughness={0.38} />
+          </mesh>
+          <mesh position={[side * -0.26, 0.82, -11.4]}>
+            <boxGeometry args={[0.026, 0.026, 25.5]} />
+            <meshStandardMaterial color="#221e1a" metalness={0.82} roughness={0.52} />
+          </mesh>
+        </group>
+      ))}
+      <group position={[0.8, 4.2, -7.5]} rotation={[0.05, 0, 0]}>
+        <mesh>
+          <boxGeometry args={[8.6, 0.07, 0.07]} />
+          <meshStandardMaterial color="#11100e" emissive="#060303" emissiveIntensity={0.22} metalness={0.9} roughness={0.42} />
+        </mesh>
+        {gantryLadderRungs.map((index) => (
+          <mesh key={`gantry-ladder-${index}`} position={[-3.9 + index * 0.86, -0.34, -0.04]} rotation={[0, 0, index % 2 === 0 ? 0.62 : -0.62]}>
+            <boxGeometry args={[0.92, 0.022, 0.028]} />
+            <meshStandardMaterial color="#211c18" metalness={0.84} roughness={0.48} />
+          </mesh>
+        ))}
+      </group>
+    </group>
+  )
+}
+
+function Tunnel({ lowPower }: { lowPower: boolean }) {
+  const activeTunnelRings = lowPower ? lowPowerTunnelRings : tunnelRings
+  const activeTunnelStruts = lowPower ? lowPowerTunnelStruts : tunnelStruts
+
   return (
     <group position={[1.35, 0, 0]}>
-      {tunnelRings.map((index) => (
+      {activeTunnelRings.map((index) => (
         <group key={index}>
           <mesh position={[0, 0.4, -index * 1.85]}>
             <torusGeometry args={[4.8 + index * 0.03, 0.035, 8, 72]} />
@@ -194,7 +370,7 @@ function Tunnel() {
           <meshStandardMaterial color="#49443d" metalness={0.9} roughness={0.45} />
         </mesh>
       ))}
-      {tunnelStruts.map((index) => (
+      {activeTunnelStruts.map((index) => (
         <mesh key={index} position={[(index % 2 ? -5.4 : 5.4), 2.9 + (index % 4) * 0.4, -index * 1.5]}>
           <cylinderGeometry args={[0.015, 0.015, 4.5, 8]} />
           <meshStandardMaterial color="#26211f" metalness={0.8} roughness={0.5} />
@@ -227,8 +403,9 @@ function CinematicLightVolume({ progress }: { progress: number }) {
   )
 }
 
-function RearTunnelCore({ progress }: { progress: number }) {
+function RearTunnelCore({ lowPower, progress }: { lowPower: boolean; progress: number }) {
   const materialRef = useRef<THREE.MeshBasicMaterial>(null)
+  const activeSpokes = lowPower ? lowPowerRearSpokeIndices : rearSpokeIndices
 
   useFrame(({ clock }) => {
     if (materialRef.current) {
@@ -250,7 +427,7 @@ function RearTunnelCore({ progress }: { progress: number }) {
         <circleGeometry args={[1.22, 64]} />
         <meshBasicMaterial ref={materialRef} color="#eee7d8" transparent opacity={0.2} depthWrite={false} blending={THREE.AdditiveBlending} />
       </mesh>
-      {rearSpokeIndices.map((index) => {
+      {activeSpokes.map((index) => {
         const angle = (index / 16) * Math.PI * 2
         return (
           <mesh key={`rear-spoke-${index}`} position={[Math.cos(angle) * 1.95, Math.sin(angle) * 1.95, 0]} rotation={[0, 0, angle]}>
@@ -263,12 +440,14 @@ function RearTunnelCore({ progress }: { progress: number }) {
   )
 }
 
-function IndustrialWallScaffolds({ progress }: { progress: number }) {
+function IndustrialWallScaffolds({ lowPower, progress }: { lowPower: boolean; progress: number }) {
+  const activeWallRibs = lowPower ? lowPowerWallRibs : wallRibs
+
   return (
     <group>
       {[-1, 1].map((side) => (
         <group key={`wall-side-${side}`} position={[side * 7.25, 1.2, -1.5]} rotation={[0, side * -0.12, 0]}>
-          {wallRibs.map((index) => (
+          {activeWallRibs.map((index) => (
             <WallRib key={`wall-rib-${side}-${index}`} index={index} progress={progress} side={side} />
           ))}
           {scaffoldLevels.map((level) => (
@@ -283,17 +462,19 @@ function IndustrialWallScaffolds({ progress }: { progress: number }) {
   )
 }
 
-function StageArchitecture() {
+function StageArchitecture({ lowPower }: { lowPower: boolean }) {
+  const activeStageRails = lowPower ? lowPowerStageRails : stageRails
+
   return (
     <group>
-      {stageRails.map((index) => (
+      {activeStageRails.map((index) => (
         <mesh key={`rail-${index}`} position={[0, -1.03, -index * 2.6]} rotation={[0, 0, 0]}>
           <boxGeometry args={[9.5, 0.018, 0.018]} />
           <meshBasicMaterial color={index % 2 === 0 ? "#8a7d6e" : "#3b332e"} />
         </mesh>
       ))}
       {[-5.8, 5.8].map((x) =>
-        stageRails.map((index) => (
+        activeStageRails.map((index) => (
           <mesh key={`walk-${x}-${index}`} position={[x, -0.75, -index * 2.4]}>
             <boxGeometry args={[0.05, 1.8, 0.05]} />
             <meshStandardMaterial color="#2d2924" emissive="#120d0c" emissiveIntensity={0.18} metalness={0.85} roughness={0.48} />
@@ -447,7 +628,11 @@ function IndustrialSideScreens({ progress }: { progress: number }) {
   )
 }
 
-function FloorRunway({ progress }: { progress: number }) {
+function FloorRunway({ lowPower, progress }: { lowPower: boolean; progress: number }) {
+  const activeRunwayPlates = lowPower ? lowPowerRunwayPlatePositions : runwayPlatePositions
+  const activeRunwayGrates = lowPower ? lowPowerRunwayGrates : runwayGrates
+  const activeFloorLights = lowPower ? lowPowerFloorLightPositions : floorLightPositions
+
   return (
     <group position={[0, -1.16, -9]}>
       {[-1, 1].map((side) => (
@@ -462,19 +647,19 @@ function FloorRunway({ progress }: { progress: number }) {
           </mesh>
         </group>
       ))}
-      {runwayPlatePositions.map((index) => (
+      {activeRunwayPlates.map((index) => (
         <mesh key={`runway-plate-${index}`} position={[0, 0.025, 8 - index * 2.15]} rotation={[-Math.PI / 2, 0, 0]}>
           <boxGeometry args={[1.95 + (index % 2) * 0.28, 1.18, 0.018]} />
           <meshStandardMaterial color="#10100f" emissive={index % 5 === 0 ? "#221110" : "#050505"} emissiveIntensity={0.22 + progress * 0.18} metalness={0.9} roughness={0.38} />
         </mesh>
       ))}
-      {runwayGrates.map((index) => (
+      {activeRunwayGrates.map((index) => (
         <mesh key={`runway-grate-${index}`} position={[0, 0.058, 7.2 - index * 1.5]} rotation={[-Math.PI / 2, 0, 0]}>
           <boxGeometry args={[1.34, 0.018, 0.016]} />
           <meshBasicMaterial color={index % 6 === 0 ? "#b51218" : "#74695d"} transparent opacity={index % 6 === 0 ? 0.44 : 0.22} />
         </mesh>
       ))}
-      {floorLightPositions.map((index) => (
+      {activeFloorLights.map((index) => (
         <mesh key={`floor-light-${index}`} position={[(index % 2 === 0 ? -1 : 1) * 1.72, 0.05, 4 - index * 2.2]}>
           <boxGeometry args={[0.62, 0.018, 0.035]} />
           <meshBasicMaterial color={index % 3 === 0 ? "#e6ded0" : "#b51218"} transparent opacity={0.62} />
@@ -488,7 +673,7 @@ function FloorRunway({ progress }: { progress: number }) {
   )
 }
 
-function ShaderFloor({ progress }: { progress: number }) {
+function ShaderFloor({ lowPower, progress }: { lowPower: boolean; progress: number }) {
   const materialRef = useRef<THREE.ShaderMaterial>(null)
   const uniforms = useMemo(
     () => ({
@@ -506,7 +691,7 @@ function ShaderFloor({ progress }: { progress: number }) {
 
   return (
     <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -1.245, -6]}>
-      <planeGeometry args={[42, 84, 28, 64]} />
+      <planeGeometry args={lowPower ? [42, 84, 14, 28] : [42, 84, 28, 64]} />
       <shaderMaterial
         ref={materialRef}
         uniforms={uniforms}
@@ -520,10 +705,12 @@ function ShaderFloor({ progress }: { progress: number }) {
   )
 }
 
-function SmokeLayer() {
+function SmokeLayer({ lowPower }: { lowPower: boolean }) {
+  const activeSmokePlumes = lowPower ? smokePlumes.slice(0, 2) : smokePlumes
+
   return (
     <group>
-      {smokePlumes.map(([x, y, z, scale], index) => (
+      {activeSmokePlumes.map(([x, y, z, scale], index) => (
         <mesh key={`smoke-${index}`} position={[x, y, z]} rotation={[0, 0, index * 0.3]}>
           <planeGeometry args={[3.2 * scale, 1.1 * scale]} />
           <meshBasicMaterial color="#d7d0c4" transparent opacity={0.055} depthWrite={false} side={THREE.DoubleSide} />
@@ -597,8 +784,8 @@ function ContactBeacon() {
   )
 }
 
-function CinematicEffects({ reducedMotion }: { reducedMotion: boolean }) {
-  if (reducedMotion) return null
+function CinematicEffects({ lowPower, reducedMotion }: { lowPower: boolean; reducedMotion: boolean }) {
+  if (reducedMotion || lowPower) return null
 
   return (
     <EffectComposer multisampling={0} enableNormalPass={false}>
@@ -611,16 +798,51 @@ function CinematicEffects({ reducedMotion }: { reducedMotion: boolean }) {
   )
 }
 
-export function IndustrialHomeExperience({ progress, reducedMotion }: IndustrialHomeExperienceProps) {
+export function IndustrialHomeExperience({ progress, reducedMotion, sceneActive }: IndustrialHomeExperienceProps) {
+  const [webglSupported, setWebglSupported] = useState<boolean | null>(null)
+  const [canvasReady, setCanvasReady] = useState(false)
+  const [deviceLowPower, setDeviceLowPower] = useState(false)
+  const [adaptiveLowPower, setAdaptiveLowPower] = useState(false)
+  const lowPower = deviceLowPower || adaptiveLowPower
+  const dpr: [number, number] = lowPower ? [1, 1.15] : [1, 1.45]
+  const frameloop = sceneActive && !reducedMotion ? "always" : "demand"
+  const handlePerformanceDecline = useCallback(() => setAdaptiveLowPower(true), [])
+
+  useEffect(() => {
+    setWebglSupported(canUseWebGL())
+    setDeviceLowPower(shouldStartLowPower())
+  }, [])
+
+  if (webglSupported === false) {
+    return (
+      <div className="industrial-canvas industrial-canvas-fallback industrial-canvas-unavailable" aria-hidden="true">
+        <div className="industrial-fallback-stage" />
+      </div>
+    )
+  }
+
   return (
-    <div className="industrial-canvas" aria-hidden="true">
-      <Canvas
-        camera={{ position: [0, 1.4, 18], fov: 42, near: 0.1, far: 90 }}
-        dpr={[1, 1.45]}
-        gl={{ antialias: true, alpha: false, powerPreference: "high-performance" }}
-      >
-        <IndustrialScene progress={progress} reducedMotion={reducedMotion} />
-      </Canvas>
+    <div className={`industrial-canvas ${canvasReady ? "is-ready" : "is-loading"} ${lowPower ? "is-low-power" : ""}`} aria-hidden="true">
+      {webglSupported ? (
+        <Canvas
+          camera={{ position: [0, 1.4, 18], fov: 42, near: 0.1, far: 90 }}
+          dpr={dpr}
+          frameloop={frameloop}
+          gl={{ antialias: !lowPower, alpha: false, powerPreference: lowPower ? "default" : "high-performance" }}
+          onCreated={({ gl }) => {
+            gl.setClearColor("#030303")
+            window.requestAnimationFrame(() => setCanvasReady(true))
+          }}
+        >
+          <IndustrialScene lowPower={lowPower} onPerformanceDecline={handlePerformanceDecline} progress={progress} reducedMotion={reducedMotion} sceneActive={sceneActive} />
+        </Canvas>
+      ) : null}
+      {!canvasReady ? (
+        <div className="industrial-canvas-loader">
+          <span>Initializing WebGL stage</span>
+          <i />
+        </div>
+      ) : null}
       <div className="industrial-stage-illustration" />
     </div>
   )

--- a/components/industrial-home-experience.tsx
+++ b/components/industrial-home-experience.tsx
@@ -828,7 +828,7 @@ export function IndustrialHomeExperience({ progress, reducedMotion, sceneActive 
           camera={{ position: [0, 1.4, 18], fov: 42, near: 0.1, far: 90 }}
           dpr={dpr}
           frameloop={frameloop}
-          gl={{ antialias: !lowPower, alpha: false, powerPreference: lowPower ? "default" : "high-performance" }}
+          gl={{ antialias: !deviceLowPower, alpha: false, powerPreference: deviceLowPower ? "default" : "high-performance" }}
           onCreated={({ gl }) => {
             gl.setClearColor("#030303")
             window.requestAnimationFrame(() => setCanvasReady(true))

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-dialog": "1.1.15",
     "@radix-ui/react-slot": "1.2.4",
     "@radix-ui/react-toast": "1.2.15",
+    "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "9.5.0",
     "@react-three/postprocessing": "^3.0.4",
     "@vercel/analytics": "1.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@radix-ui/react-toast':
         specifier: 1.2.15
         version: 1.2.15(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@react-three/drei':
+        specifier: ^10.7.7
+        version: 10.7.7(93237fae5f693178508611c9c4972e25)
       '@react-three/fiber':
         specifier: 9.5.0
         version: 9.5.0(@types/react@19.0.0)(expo-asset@11.1.5(expo@53.0.11(@babel/core@7.27.4)(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(expo-file-system@18.1.10(expo@53.0.11(@babel/core@7.27.4)(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0)))(expo-gl@15.1.6(expo@53.0.11(@babel/core@7.27.4)(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(expo@53.0.11(@babel/core@7.27.4)(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)(three@0.182.0)
@@ -1183,6 +1186,14 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
+  '@mediapipe/tasks-vision@0.10.17':
+    resolution: {integrity: sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==}
+
+  '@monogrid/gainmap-js@3.4.0':
+    resolution: {integrity: sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==}
+    peerDependencies:
+      three: '>= 0.159.0'
+
   '@napi-rs/wasm-runtime@0.2.11':
     resolution: {integrity: sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==}
 
@@ -1565,6 +1576,17 @@ packages:
       '@types/react':
         optional: true
 
+  '@react-three/drei@10.7.7':
+    resolution: {integrity: sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==}
+    peerDependencies:
+      '@react-three/fiber': ^9.0.0
+      react: ^19
+      react-dom: ^19
+      three: '>=0.159'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   '@react-three/fiber@9.5.0':
     resolution: {integrity: sha512-FiUzfYW4wB1+PpmsE47UM+mCads7j2+giRBltfwH7SNhah95rqJs3ltEs9V3pP8rYdS0QlNne+9Aj8dS/SiaIA==}
     peerDependencies:
@@ -1801,6 +1823,9 @@ packages:
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
+  '@types/draco3d@1.4.10':
+    resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
+
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
@@ -1830,6 +1855,9 @@ packages:
 
   '@types/node@22.0.0':
     resolution: {integrity: sha512-VT7KSYudcPOzP5Q0wfbowyNLaVR8QWUdw+088uFWwfvpY6uCWaXpqV6ieLAu9WBcnTa7H4Z5RLK8I5t2FuOcqw==}
+
+  '@types/offscreencanvas@2019.7.3':
+    resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
 
   '@types/react-dom@19.0.0':
     resolution: {integrity: sha512-1KfiQKsH1o00p9m5ag12axHQSb3FOU9H20UTrujVSkNhuCrRHiQWFqgEnTNK5ZNfnzZv8UWrnXVqCmCF9fgY3w==}
@@ -2025,6 +2053,14 @@ packages:
     resolution: {integrity: sha512-EEmtFu8JTuwsInqMakhLq+U3qN8ZMd5V3pX44q0EqD2imqTDsa8ikZqJ1schVrN8HljOdN+C08cwZ1/r5uIgLw==}
     peerDependencies:
       '@urql/core': ^5.0.0
+
+  '@use-gesture/core@10.3.1':
+    resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}
+
+  '@use-gesture/react@10.3.1':
+    resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
+    peerDependencies:
+      react: '>= 16.8.0'
 
   '@vercel/analytics@1.6.1':
     resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
@@ -2329,6 +2365,9 @@ packages:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
     engines: {node: '>=12.0.0'}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
@@ -2426,6 +2465,12 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
+
+  camera-controls@3.1.2:
+    resolution: {integrity: sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==}
+    engines: {node: '>=22.0.0', npm: '>=10.5.1'}
+    peerDependencies:
+      three: '>=0.126.1'
 
   caniuse-lite@1.0.30001723:
     resolution: {integrity: sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==}
@@ -2578,6 +2623,11 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
 
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2676,6 +2726,9 @@ packages:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  detect-gpu@5.0.70:
+    resolution: {integrity: sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==}
+
   detect-libc@1.0.3:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
     engines: {node: '>=0.10'}
@@ -2729,6 +2782,9 @@ packages:
   dotenv@16.4.7:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
     engines: {node: '>=12'}
+
+  draco3d@1.5.7:
+    resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3099,6 +3155,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.6.10:
+    resolution: {integrity: sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==}
+
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
@@ -3258,6 +3317,9 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  glsl-noise@0.0.0:
+    resolution: {integrity: sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -3311,6 +3373,9 @@ packages:
   hermes-parser@0.28.1:
     resolution: {integrity: sha512-nf8o+hE8g7UJWParnccljHumE9Vlq8F7MqIdeahl+4x0tvCUJYRrT0L7h0MMg/X9YJmkNwsfbaNNrzPtFXOscg==}
 
+  hls.js@1.6.16:
+    resolution: {integrity: sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==}
+
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -3352,6 +3417,9 @@ packages:
     resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
     engines: {node: '>=16.x'}
     hasBin: true
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   import-fresh@2.0.0:
     resolution: {integrity: sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==}
@@ -3480,6 +3548,9 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-promise@2.2.2:
+    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
@@ -3812,6 +3883,9 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+
   lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
 
@@ -3928,6 +4002,12 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
 
+  maath@0.10.8:
+    resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
+    peerDependencies:
+      '@types/three': '>=0.134.0'
+      three: '>=0.134.0'
+
   maath@0.6.0:
     resolution: {integrity: sha512-dSb2xQuP7vDnaYqfoKzlApeRcR2xtN8/f7WV/TMAkBC8552TwTLtOO0JTcSygkYMjNDPoo6V01jTw/aPi4JrMw==}
     peerDependencies:
@@ -3963,6 +4043,11 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  meshline@3.3.1:
+    resolution: {integrity: sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==}
+    peerDependencies:
+      three: '>=0.137'
 
   meshoptimizer@0.22.0:
     resolution: {integrity: sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==}
@@ -4436,6 +4521,9 @@ packages:
     peerDependencies:
       three: '>= 0.168.0 < 0.185.0'
 
+  potpack@1.0.2:
+    resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -4460,6 +4548,9 @@ packages:
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+
+  promise-worker-transferable@1.0.4:
+    resolution: {integrity: sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==}
 
   promise@8.3.0:
     resolution: {integrity: sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==}
@@ -4888,6 +4979,15 @@ packages:
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
+  stats-gl@2.4.2:
+    resolution: {integrity: sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==}
+    peerDependencies:
+      '@types/three': '*'
+      three: '*'
+
+  stats.js@0.17.0:
+    resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
@@ -5070,6 +5170,16 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  three-mesh-bvh@0.8.3:
+    resolution: {integrity: sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==}
+    peerDependencies:
+      three: '>= 0.159.0'
+
+  three-stdlib@2.36.1:
+    resolution: {integrity: sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==}
+    peerDependencies:
+      three: '>=0.128.0'
+
   three@0.182.0:
     resolution: {integrity: sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==}
 
@@ -5094,6 +5204,19 @@ packages:
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  troika-three-text@0.52.4:
+    resolution: {integrity: sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==}
+    peerDependencies:
+      three: '>=0.125.0'
+
+  troika-three-utils@0.52.4:
+    resolution: {integrity: sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==}
+    peerDependencies:
+      three: '>=0.125.0'
+
+  troika-worker-utils@0.52.0:
+    resolution: {integrity: sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -5136,6 +5259,9 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tunnel-rat@0.1.2:
+    resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
 
   turbo-stream@2.4.1:
     resolution: {integrity: sha512-v8kOJXpG3WoTN/+at8vK7erSzo6nW6CIaeOvNOkHQVDajfz1ZVeSxCbc6tOH4hrGZW7VUCV0TOXd8CPzYnYkrw==}
@@ -5256,6 +5382,10 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  utility-types@3.11.0:
+    resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
+    engines: {node: '>= 4'}
+
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
@@ -5354,6 +5484,12 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  webgl-constants@1.1.1:
+    resolution: {integrity: sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==}
+
+  webgl-sdf-generator@1.1.1:
+    resolution: {integrity: sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==}
 
   webidl-conversions@5.0.0:
     resolution: {integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==}
@@ -5494,6 +5630,21 @@ packages:
 
   zimmerframe@1.1.2:
     resolution: {integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
   zustand@5.0.5:
     resolution: {integrity: sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==}
@@ -6956,6 +7107,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@mediapipe/tasks-vision@0.10.17': {}
+
+  '@monogrid/gainmap-js@3.4.0(three@0.182.0)':
+    dependencies:
+      promise-worker-transferable: 1.0.4
+      three: 0.182.0
+
   '@napi-rs/wasm-runtime@0.2.11':
     dependencies:
       '@emnapi/core': 1.4.3
@@ -7378,6 +7536,39 @@ snapshots:
       '@types/react': 19.0.0
     optional: true
 
+  '@react-three/drei@10.7.7(93237fae5f693178508611c9c4972e25)':
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@mediapipe/tasks-vision': 0.10.17
+      '@monogrid/gainmap-js': 3.4.0(three@0.182.0)
+      '@react-three/fiber': 9.5.0(@types/react@19.0.0)(expo-asset@11.1.5(expo@53.0.11(@babel/core@7.27.4)(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(expo-file-system@18.1.10(expo@53.0.11(@babel/core@7.27.4)(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0)))(expo-gl@15.1.6(expo@53.0.11(@babel/core@7.27.4)(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(expo@53.0.11(@babel/core@7.27.4)(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)(three@0.182.0)
+      '@use-gesture/react': 10.3.1(react@19.0.0)
+      camera-controls: 3.1.2(three@0.182.0)
+      cross-env: 7.0.3
+      detect-gpu: 5.0.70
+      glsl-noise: 0.0.0
+      hls.js: 1.6.16
+      maath: 0.10.8(@types/three@0.182.0)(three@0.182.0)
+      meshline: 3.3.1(three@0.182.0)
+      react: 19.0.0
+      stats-gl: 2.4.2(@types/three@0.182.0)(three@0.182.0)
+      stats.js: 0.17.0
+      suspend-react: 0.1.3(react@19.0.0)
+      three: 0.182.0
+      three-mesh-bvh: 0.8.3(three@0.182.0)
+      three-stdlib: 2.36.1(three@0.182.0)
+      troika-three-text: 0.52.4(three@0.182.0)
+      tunnel-rat: 0.1.2(@types/react@19.0.0)(react@19.0.0)
+      use-sync-external-store: 1.5.0(react@19.0.0)
+      utility-types: 3.11.0
+      zustand: 5.0.5(@types/react@19.0.0)(react@19.0.0)(use-sync-external-store@1.5.0(react@19.0.0))
+    optionalDependencies:
+      react-dom: 19.0.0(react@19.0.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/three'
+      - immer
+
   '@react-three/fiber@9.5.0(@types/react@19.0.0)(expo-asset@11.1.5(expo@53.0.11(@babel/core@7.27.4)(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(expo-file-system@18.1.10(expo@53.0.11(@babel/core@7.27.4)(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0)))(expo-gl@15.1.6(expo@53.0.11(@babel/core@7.27.4)(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(expo@53.0.11(@babel/core@7.27.4)(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)(three@0.182.0)':
     dependencies:
       '@babel/runtime': 7.27.6
@@ -7614,6 +7805,8 @@ snapshots:
   '@types/cookie@0.6.0':
     optional: true
 
+  '@types/draco3d@1.4.10': {}
+
   '@types/estree@1.0.7':
     optional: true
 
@@ -7645,6 +7838,8 @@ snapshots:
   '@types/node@22.0.0':
     dependencies:
       undici-types: 6.11.1
+
+  '@types/offscreencanvas@2019.7.3': {}
 
   '@types/react-dom@19.0.0':
     dependencies:
@@ -7847,6 +8042,13 @@ snapshots:
       '@urql/core': 5.1.1
       wonka: 6.3.5
     optional: true
+
+  '@use-gesture/core@10.3.1': {}
+
+  '@use-gesture/react@10.3.1(react@19.0.0)':
+    dependencies:
+      '@use-gesture/core': 10.3.1
+      react: 19.0.0
 
   '@vercel/analytics@1.6.1(@remix-run/react@2.16.8(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.0.2))(@sveltejs/kit@2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.5)(vite@6.3.5(@types/node@22.0.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.0)(yaml@2.8.0)))(svelte@5.34.5)(vite@6.3.5(@types/node@22.0.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.0)(yaml@2.8.0)))(next@15.2.8(@babel/core@7.27.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.34.5)(vue-router@4.5.1(vue@3.5.16(typescript@5.0.2)))(vue@3.5.16(typescript@5.0.2))':
     optionalDependencies:
@@ -8272,6 +8474,10 @@ snapshots:
       open: 8.4.2
     optional: true
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   big-integer@1.6.52:
     optional: true
 
@@ -8377,6 +8583,10 @@ snapshots:
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
+
+  camera-controls@3.1.2(three@0.182.0):
+    dependencies:
+      three: 0.182.0
 
   caniuse-lite@1.0.30001723: {}
 
@@ -8573,6 +8783,10 @@ snapshots:
       - supports-color
       - ts-node
 
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.6
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -8654,6 +8868,10 @@ snapshots:
   destroy@1.2.0:
     optional: true
 
+  detect-gpu@5.0.70:
+    dependencies:
+      webgl-constants: 1.1.1
+
   detect-libc@1.0.3:
     optional: true
 
@@ -8706,6 +8924,8 @@ snapshots:
 
   dotenv@16.4.7:
     optional: true
+
+  draco3d@1.5.7: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -9272,6 +9492,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
+  fflate@0.6.10: {}
+
   fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
@@ -9444,6 +9666,8 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  glsl-noise@0.0.0: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -9490,6 +9714,8 @@ snapshots:
     dependencies:
       hermes-estree: 0.28.1
     optional: true
+
+  hls.js@1.6.16: {}
 
   hosted-git-info@7.0.2:
     dependencies:
@@ -9544,6 +9770,8 @@ snapshots:
     dependencies:
       queue: 6.0.2
     optional: true
+
+  immediate@3.0.6: {}
 
   import-fresh@2.0.0:
     dependencies:
@@ -9674,6 +9902,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
+
+  is-promise@2.2.2: {}
 
   is-reference@3.0.3:
     dependencies:
@@ -10222,6 +10452,10 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
+
   lighthouse-logger@1.4.2:
     dependencies:
       debug: 2.6.9
@@ -10320,6 +10554,11 @@ snapshots:
     dependencies:
       react: 19.0.0
 
+  maath@0.10.8(@types/three@0.182.0)(three@0.182.0):
+    dependencies:
+      '@types/three': 0.182.0
+      three: 0.182.0
+
   maath@0.6.0(@types/three@0.182.0)(three@0.182.0):
     dependencies:
       '@types/three': 0.182.0
@@ -10351,6 +10590,10 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  meshline@3.3.1(three@0.182.0):
+    dependencies:
+      three: 0.182.0
 
   meshoptimizer@0.22.0: {}
 
@@ -10958,6 +11201,8 @@ snapshots:
     dependencies:
       three: 0.182.0
 
+  potpack@1.0.2: {}
+
   prelude-ls@1.2.1: {}
 
   prettier@3.5.3:
@@ -10977,6 +11222,11 @@ snapshots:
 
   progress@2.0.3:
     optional: true
+
+  promise-worker-transferable@1.0.4:
+    dependencies:
+      is-promise: 2.2.2
+      lie: 3.3.0
 
   promise@8.3.0:
     dependencies:
@@ -11211,8 +11461,7 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  require-from-string@2.0.2:
-    optional: true
+  require-from-string@2.0.2: {}
 
   requireg@0.2.2:
     dependencies:
@@ -11568,6 +11817,13 @@ snapshots:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
 
+  stats-gl@2.4.2(@types/three@0.182.0)(three@0.182.0):
+    dependencies:
+      '@types/three': 0.182.0
+      three: 0.182.0
+
+  stats.js@0.17.0: {}
+
   statuses@1.5.0:
     optional: true
 
@@ -11817,6 +12073,20 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  three-mesh-bvh@0.8.3(three@0.182.0):
+    dependencies:
+      three: 0.182.0
+
+  three-stdlib@2.36.1(three@0.182.0):
+    dependencies:
+      '@types/draco3d': 1.4.10
+      '@types/offscreencanvas': 2019.7.3
+      '@types/webxr': 0.5.22
+      draco3d: 1.5.7
+      fflate: 0.6.10
+      potpack: 1.0.2
+      three: 0.182.0
+
   three@0.182.0: {}
 
   throat@5.0.0:
@@ -11838,6 +12108,20 @@ snapshots:
 
   totalist@3.0.1:
     optional: true
+
+  troika-three-text@0.52.4(three@0.182.0):
+    dependencies:
+      bidi-js: 1.0.3
+      three: 0.182.0
+      troika-three-utils: 0.52.4(three@0.182.0)
+      troika-worker-utils: 0.52.0
+      webgl-sdf-generator: 1.1.1
+
+  troika-three-utils@0.52.4(three@0.182.0):
+    dependencies:
+      three: 0.182.0
+
+  troika-worker-utils@0.52.0: {}
 
   ts-api-utils@2.1.0(typescript@5.0.2):
     dependencies:
@@ -11873,6 +12157,14 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tunnel-rat@0.1.2(@types/react@19.0.0)(react@19.0.0):
+    dependencies:
+      zustand: 4.5.7(@types/react@19.0.0)(react@19.0.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
 
   turbo-stream@2.4.1:
     optional: true
@@ -12015,6 +12307,8 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  utility-types@3.11.0: {}
+
   utils-merge@1.0.1:
     optional: true
 
@@ -12089,6 +12383,10 @@ snapshots:
     dependencies:
       defaults: 1.0.4
     optional: true
+
+  webgl-constants@1.1.1: {}
+
+  webgl-sdf-generator@1.1.1: {}
 
   webidl-conversions@5.0.0:
     optional: true
@@ -12232,6 +12530,13 @@ snapshots:
 
   zimmerframe@1.1.2:
     optional: true
+
+  zustand@4.5.7(@types/react@19.0.0)(react@19.0.0):
+    dependencies:
+      use-sync-external-store: 1.5.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.0
+      react: 19.0.0
 
   zustand@5.0.5(@types/react@19.0.0)(react@19.0.0)(use-sync-external-store@1.5.0(react@19.0.0)):
     optionalDependencies:


### PR DESCRIPTION
## Summary
- add Drei-backed performance helpers, adaptive DPR, WebGL detection, loading state, and low-power mode for the immersive home canvas
- deepen the industrial scene with foreground rail/catwalk geometry, denser gantry detail, particles, and tuned contrast against the accepted reference concept
- pause the render loop when the page is hidden/inactive and keep non-home routes from loading the immersive canvas

## Validation
- pnpm lint
- pnpm type-check
- pnpm test:unit
- pnpm build
- Browser QA on production start: / renders one visible canvas with no console errors; /projects renders with zero canvases and no console errors
- Browser QA on mobile viewport: homepage remains readable with one visible canvas and no console errors