### PR TITLE
Push industrial scene closer to concept art

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -23,6 +23,8 @@
   --border: 24 8% 18%;
   --input: 24 8% 18%;
   --ring: 358 78% 39%;
+  --industrial-red-glow-soft: 0 0 24px rgba(255,37,43,0.8), 0 0 70px rgba(181,18,24,0.45);
+  --industrial-red-glow-intense: 0 0 28px rgba(255,37,43,0.95), 0 0 100px rgba(181,18,24,0.68), 0 0 180px rgba(181,18,24,0.28);
 }
 
 /* Dark theme variables */
@@ -409,7 +411,7 @@ html {
   height: 9rem;
   top: 22%;
   background: linear-gradient(180deg, transparent, #ff252b 18%, #ff252b 78%, transparent);
-  box-shadow: 0 0 24px rgba(255,37,43,0.8), 0 0 70px rgba(181,18,24,0.45);
+  box-shadow: var(--industrial-red-glow-soft);
 }
 
 .industrial-atmosphere-tower::after {
@@ -483,7 +485,7 @@ html {
 
 .industrial-home[data-active-section="contact"] .industrial-atmosphere-light-b {
   opacity: 1;
-  box-shadow: 0 0 28px rgba(255,37,43,0.95), 0 0 100px rgba(181,18,24,0.68), 0 0 180px rgba(181,18,24,0.28);
+  box-shadow: var(--industrial-red-glow-intense);
 }
 
 .industrial-stage-illustration {
@@ -954,6 +956,7 @@ html {
 }
 
 .industrial-contact-section {
+  --industrial-contact-beam-x: 50.5%; /* Optical center between writing and contact columns in the concept outro. */
   position: relative;
   grid-template-columns: minmax(16rem, 0.86fr) minmax(20rem, 0.95fr);
 }
@@ -961,14 +964,14 @@ html {
 .industrial-contact-section::before {
   content: "";
   position: absolute;
-  left: 50.5%;
+  left: var(--industrial-contact-beam-x);
   top: 18%;
   bottom: 10%;
   z-index: 0;
   width: 0.24rem;
   transform: translateX(-50%);
   background: linear-gradient(180deg, transparent, #ff252b 14%, #ff252b 84%, transparent);
-  box-shadow: 0 0 28px rgba(255,37,43,0.95), 0 0 100px rgba(181,18,24,0.62), 0 0 180px rgba(181,18,24,0.3);
+  box-shadow: var(--industrial-red-glow-intense);
 }
 
 .industrial-contact-section::after {

--- a/app/globals.css
+++ b/app/globals.css
@@ -242,10 +242,10 @@ html {
   inset: 0;
   z-index: 0;
   background:
-    linear-gradient(90deg, rgba(0,0,0,0.98) 0 8%, rgba(0,0,0,0.76) 26%, transparent 50%, rgba(0,0,0,0.42) 76%, rgba(0,0,0,0.66) 100%),
-    radial-gradient(circle at 52% 31%, rgba(239,231,216,0.16), transparent 11rem),
-    radial-gradient(circle at 79% 35%, rgba(181,18,24,0.24), transparent 13rem),
-    radial-gradient(ellipse at 62% 78%, rgba(238,231,216,0.11), transparent 20rem),
+    linear-gradient(90deg, rgba(0,0,0,0.98) 0 7%, rgba(0,0,0,0.7) 24%, transparent 50%, rgba(0,0,0,0.34) 72%, rgba(0,0,0,0.72) 100%),
+    radial-gradient(circle at 56% 34%, rgba(239,231,216,0.22), transparent 9rem),
+    radial-gradient(circle at 79% 35%, rgba(181,18,24,0.28), transparent 12rem),
+    radial-gradient(ellipse at 58% 78%, rgba(238,231,216,0.14), transparent 18rem),
     linear-gradient(180deg, transparent 0 57%, rgba(0,0,0,0.65) 82%, #030303 100%);
 }
 
@@ -313,9 +313,10 @@ html {
 }
 
 .industrial-atmosphere-light-b {
-  left: 45%;
-  bottom: 8%;
-  height: 24rem;
+  left: 50%;
+  bottom: 11%;
+  width: 0.22rem;
+  height: 28rem;
   transform: translateX(-50%);
   opacity: 0;
 }
@@ -332,7 +333,7 @@ html {
     radial-gradient(ellipse at 42% 0%, transparent 0 54%, rgba(0,0,0,0.9) 55% 56%, transparent 57%),
     radial-gradient(ellipse at 70% 0%, transparent 0 48%, rgba(0,0,0,0.92) 49% 50%, transparent 51%),
     repeating-linear-gradient(104deg, transparent 0 5rem, rgba(0,0,0,0.85) 5.05rem 5.18rem, transparent 5.24rem 9rem);
-  opacity: 0.72;
+  opacity: 0.86;
 }
 
 .industrial-atmosphere-floor {
@@ -348,7 +349,7 @@ html {
     linear-gradient(180deg, transparent, rgba(238,231,216,0.16));
   transform: perspective(760px) rotateX(66deg);
   transform-origin: bottom;
-  opacity: 0.58;
+  opacity: 0.72;
 }
 
 .industrial-atmosphere-gantry {
@@ -381,6 +382,70 @@ html {
   transform: perspective(820px) rotateY(-22deg);
   transform-origin: right center;
   mask-image: linear-gradient(90deg, transparent 0, black 42% 100%);
+}
+
+.industrial-atmosphere-tower {
+  position: absolute;
+  z-index: 2;
+  top: 3%;
+  bottom: 10%;
+  width: min(23vw, 22rem);
+  pointer-events: none;
+  background:
+    repeating-linear-gradient(90deg, rgba(238,231,216,0.12) 0 1px, transparent 1px 2.1rem),
+    repeating-linear-gradient(0deg, rgba(238,231,216,0.08) 0 1px, transparent 1px 2.8rem),
+    linear-gradient(25deg, transparent 0 47%, rgba(0,0,0,0.95) 47.4% 49%, transparent 49.4%),
+    linear-gradient(155deg, transparent 0 51%, rgba(0,0,0,0.9) 51.4% 52.8%, transparent 53.2%),
+    linear-gradient(90deg, rgba(0,0,0,0.94), rgba(0,0,0,0.16));
+  opacity: 0.44;
+  box-shadow: inset 0 0 80px rgba(0,0,0,0.95);
+}
+
+.industrial-atmosphere-tower::before,
+.industrial-atmosphere-tower::after {
+  content: "";
+  position: absolute;
+  width: 0.22rem;
+  height: 9rem;
+  top: 22%;
+  background: linear-gradient(180deg, transparent, #ff252b 18%, #ff252b 78%, transparent);
+  box-shadow: 0 0 24px rgba(255,37,43,0.8), 0 0 70px rgba(181,18,24,0.45);
+}
+
+.industrial-atmosphere-tower::after {
+  top: 47%;
+  height: 5.8rem;
+  opacity: 0.64;
+}
+
+.industrial-atmosphere-tower-left {
+  left: -1%;
+  transform: perspective(900px) rotateY(30deg);
+  transform-origin: left center;
+  mask-image: linear-gradient(90deg, black 0 66%, transparent 100%);
+}
+
+.industrial-atmosphere-tower-left::before {
+  right: 3.8rem;
+}
+
+.industrial-atmosphere-tower-left::after {
+  right: 7.2rem;
+}
+
+.industrial-atmosphere-tower-right {
+  right: -1%;
+  transform: perspective(900px) rotateY(-28deg);
+  transform-origin: right center;
+  mask-image: linear-gradient(90deg, transparent 0, black 32% 100%);
+}
+
+.industrial-atmosphere-tower-right::before {
+  left: 3.4rem;
+}
+
+.industrial-atmosphere-tower-right::after {
+  left: 7.8rem;
 }
 
 .industrial-atmosphere-smoke {
@@ -418,6 +483,7 @@ html {
 
 .industrial-home[data-active-section="contact"] .industrial-atmosphere-light-b {
   opacity: 1;
+  box-shadow: 0 0 28px rgba(255,37,43,0.95), 0 0 100px rgba(181,18,24,0.68), 0 0 180px rgba(181,18,24,0.28);
 }
 
 .industrial-stage-illustration {
@@ -425,13 +491,13 @@ html {
   inset: 0;
   pointer-events: none;
   background:
-    linear-gradient(90deg, rgba(0,0,0,0.9) 0 16%, transparent 44%, rgba(0,0,0,0.72) 100%),
-    radial-gradient(circle at 56% 42%, rgba(232,225,210,0.13), transparent 7rem),
+    linear-gradient(90deg, rgba(0,0,0,0.9) 0 15%, transparent 46%, rgba(0,0,0,0.72) 100%),
+    radial-gradient(circle at 57% 41%, rgba(232,225,210,0.2), transparent 6.2rem),
     radial-gradient(circle at 78% 40%, rgba(181,18,24,0.2), transparent 14rem),
     repeating-radial-gradient(ellipse at 57% 43%, rgba(232,225,210,0.16) 0 1px, transparent 1px 22px),
     linear-gradient(115deg, transparent 0 48%, rgba(232,225,210,0.18) 49%, transparent 50% 100%),
     linear-gradient(75deg, transparent 0 52%, rgba(232,225,210,0.12) 53%, transparent 54% 100%);
-  opacity: 0.26;
+  opacity: 0.22;
   mask-image: linear-gradient(90deg, transparent 0 42%, black 54% 100%);
 }
 
@@ -516,11 +582,12 @@ html {
 
 .industrial-hero-section {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
+  padding-top: clamp(11.6rem, 24vh, 15.6rem);
 }
 
 .industrial-hero-copy {
-  max-width: 46rem;
+  max-width: 34rem;
 }
 
 .industrial-hero-copy h1,
@@ -537,16 +604,16 @@ html {
 }
 
 .industrial-hero-copy h1 {
-  max-width: 8ch;
-  font-size: clamp(4.8rem, 12vw, 9.8rem);
-  text-shadow: 0 0 18px rgba(255,255,255,0.12);
+  max-width: 6.7ch;
+  font-size: clamp(4.15rem, 8.5vw, 7.35rem);
+  text-shadow: 0 0 14px rgba(255,255,255,0.11), 0 0 44px rgba(0,0,0,0.8);
 }
 
 .industrial-hero-copy p {
-  max-width: 34rem;
+  max-width: 29rem;
   margin-top: 1.2rem;
   color: #d4cbbb;
-  font-size: clamp(1rem, 2vw, 1.25rem);
+  font-size: clamp(0.92rem, 1.35vw, 1.06rem);
   line-height: 1.75;
 }
 
@@ -600,22 +667,22 @@ html {
 .industrial-section-rail {
   position: fixed;
   left: clamp(1rem, 3vw, 2rem);
-  top: 24%;
+  top: 27%;
   z-index: 4;
   display: grid;
-  gap: 3.3rem;
-  color: rgba(232, 225, 210, 0.56);
-  font-size: 0.72rem;
+  gap: 3.6rem;
+  color: rgba(232, 225, 210, 0.7);
+  font-size: 0.68rem;
 }
 
 .industrial-section-rail::before {
   content: "";
   position: absolute;
   left: 50%;
-  top: 1rem;
-  bottom: 1rem;
+  top: 0.95rem;
+  bottom: 0.95rem;
   width: 1px;
-  background: linear-gradient(#b51218, rgba(232,225,210,0.2), transparent);
+  background: linear-gradient(#b51218, rgba(232,225,210,0.42), transparent);
 }
 
 .industrial-section-rail span {
@@ -887,7 +954,43 @@ html {
 }
 
 .industrial-contact-section {
+  position: relative;
   grid-template-columns: minmax(16rem, 0.86fr) minmax(20rem, 0.95fr);
+}
+
+.industrial-contact-section::before {
+  content: "";
+  position: absolute;
+  left: 50.5%;
+  top: 18%;
+  bottom: 10%;
+  z-index: 0;
+  width: 0.24rem;
+  transform: translateX(-50%);
+  background: linear-gradient(180deg, transparent, #ff252b 14%, #ff252b 84%, transparent);
+  box-shadow: 0 0 28px rgba(255,37,43,0.95), 0 0 100px rgba(181,18,24,0.62), 0 0 180px rgba(181,18,24,0.3);
+}
+
+.industrial-contact-section::after {
+  content: "";
+  position: absolute;
+  left: 35%;
+  right: 26%;
+  bottom: 9%;
+  z-index: 0;
+  height: 7rem;
+  background:
+    radial-gradient(ellipse at 50% 18%, rgba(181,18,24,0.32), transparent 9rem),
+    repeating-linear-gradient(90deg, rgba(238,231,216,0.12) 0 1px, transparent 1px 3.5rem),
+    linear-gradient(180deg, transparent, rgba(238,231,216,0.1));
+  transform: perspective(760px) rotateX(66deg);
+  transform-origin: bottom;
+  opacity: 0.58;
+}
+
+.industrial-contact-section > * {
+  position: relative;
+  z-index: 1;
 }
 
 .industrial-writing-list {
@@ -1088,6 +1191,16 @@ html {
     left: 4%;
     right: -20%;
     opacity: 0.28;
+  }
+
+  .industrial-atmosphere-tower-left {
+    opacity: 0.18;
+  }
+
+  .industrial-atmosphere-tower-right {
+    right: -20%;
+    width: 52vw;
+    opacity: 0.24;
   }
 
   .industrial-hero-copy {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -113,6 +113,8 @@ export default function Home() {
         <span className="industrial-atmosphere-floor" />
         <span className="industrial-atmosphere-gantry industrial-atmosphere-gantry-left" />
         <span className="industrial-atmosphere-gantry industrial-atmosphere-gantry-right" />
+        <span className="industrial-atmosphere-tower industrial-atmosphere-tower-left" />
+        <span className="industrial-atmosphere-tower industrial-atmosphere-tower-right" />
         <span className="industrial-atmosphere-smoke" />
       </div>
       <aside className="industrial-section-rail" aria-hidden="true">

--- a/components/industrial-home-experience.tsx
+++ b/components/industrial-home-experience.tsx
@@ -8,8 +8,8 @@ import * as THREE from "three"
 import { BlendFunction } from "postprocessing"
 import { featuredPortfolioProjects, portfolioCapabilities } from "@/data/portfolio"
 
-const tunnelRings = Array.from({ length: 18 }, (_, index) => index)
-const lowPowerTunnelRings = tunnelRings.filter((index) => index < 16 && index % 2 === 0)
+const tunnelRings = Array.from({ length: 24 }, (_, index) => index)
+const lowPowerTunnelRings = tunnelRings.filter((index) => index < 22 && index % 2 === 0)
 const stageRails = Array.from({ length: 14 }, (_, index) => index)
 const lowPowerStageRails = stageRails.filter((index) => index % 2 === 0)
 const towerPositions = [
@@ -51,6 +51,11 @@ const heroLightStacks = Array.from({ length: 8 }, (_, index) => index)
 const foregroundRailPosts = Array.from({ length: 12 }, (_, index) => index)
 const lowPowerForegroundRailPosts = foregroundRailPosts.filter((index) => index % 2 === 0)
 const gantryLadderRungs = Array.from({ length: 10 }, (_, index) => index)
+const apertureSpokes = Array.from({ length: 28 }, (_, index) => index)
+const lowPowerApertureSpokes = apertureSpokes.filter((index) => index % 2 === 0)
+const verticalLightStackRows = Array.from({ length: 9 }, (_, index) => index)
+const slabCableIndices = Array.from({ length: 4 }, (_, index) => index)
+const beaconSteps = Array.from({ length: 5 }, (_, index) => index)
 const smokePlumes = [
   [-3.6, -0.65, -4, 1.2],
   [3.5, -0.72, -7, 1.5],
@@ -200,6 +205,7 @@ function IndustrialScene({
         <IndustrialParticles lowPower={lowPower} />
         <Tunnel lowPower={lowPower} />
         <HeroSetPieces lowPower={lowPower} progress={progress} />
+        <IndustrialLightStacks lowPower={lowPower} progress={progress} />
         <ForegroundRunwayRig lowPower={lowPower} progress={progress} />
         <RearTunnelCore lowPower={lowPower} progress={progress} />
         <IndustrialWallScaffolds lowPower={lowPower} progress={progress} />
@@ -289,6 +295,36 @@ function HeroSetPieces({ lowPower, progress }: { lowPower: boolean; progress: nu
   )
 }
 
+function IndustrialLightStacks({ lowPower, progress }: { lowPower: boolean; progress: number }) {
+  const rows = lowPower ? verticalLightStackRows.filter((index) => index % 2 === 0) : verticalLightStackRows
+  const stacks = [
+    [-6.3, 1.2, -9.2, 0.18],
+    [6.8, 1.6, -8.4, -0.18],
+    [7.75, 2.4, -14.6, -0.28],
+    [-7.4, 2.2, -16.2, 0.22],
+  ] as const
+
+  return (
+    <group>
+      {stacks.map(([x, y, z, rotY], stackIndex) => (
+        <group key={`industrial-light-stack-${stackIndex}`} position={[x, y, z]} rotation={[0, rotY, 0]}>
+          <mesh position={[0, 1.5, 0]}>
+            <boxGeometry args={[0.16, 4.1, 0.12]} />
+            <meshStandardMaterial color="#090807" emissive="#120606" emissiveIntensity={0.26} metalness={0.86} roughness={0.48} />
+          </mesh>
+          {rows.map((row) => (
+            <mesh key={`stack-light-${stackIndex}-${row}`} position={[0, -0.05 + row * 0.38, 0.08]}>
+              <boxGeometry args={[0.05, 0.15, 0.035]} />
+              <meshBasicMaterial color={row % 3 === 0 ? "#eee7d8" : "#ff252b"} transparent opacity={0.54 + progress * 0.18} />
+            </mesh>
+          ))}
+          <pointLight position={[0, 1.45, 0.4]} intensity={2.2 + progress * 1.4} color="#b51218" distance={5.8} />
+        </group>
+      ))}
+    </group>
+  )
+}
+
 function ForegroundRunwayRig({ lowPower, progress }: { lowPower: boolean; progress: number }) {
   const activePosts = lowPower ? lowPowerForegroundRailPosts : foregroundRailPosts
   const glowOpacity = 0.42 + progress * 0.18
@@ -364,6 +400,20 @@ function Tunnel({ lowPower }: { lowPower: boolean }) {
           </mesh>
         </group>
       ))}
+      {activeTunnelRings
+        .filter((index) => index % 3 === 0)
+        .map((index) => (
+          <group key={`tunnel-cross-${index}`} position={[0, 0.4, -index * 1.85]}>
+            <mesh rotation={[0, 0, Math.PI / 4]}>
+              <boxGeometry args={[7.2, 0.018, 0.018]} />
+              <meshStandardMaterial color="#1b1714" emissive="#080504" emissiveIntensity={0.2} metalness={0.8} roughness={0.5} />
+            </mesh>
+            <mesh rotation={[0, 0, -Math.PI / 4]}>
+              <boxGeometry args={[7.2, 0.018, 0.018]} />
+              <meshStandardMaterial color="#1b1714" emissive="#080504" emissiveIntensity={0.2} metalness={0.8} roughness={0.5} />
+            </mesh>
+          </group>
+        ))}
       {[-3.2, 3.2].map((x) => (
         <mesh key={x} position={[x, -0.8, -12]} rotation={[0, 0, 0]}>
           <boxGeometry args={[0.08, 0.08, 34]} />
@@ -406,6 +456,7 @@ function CinematicLightVolume({ progress }: { progress: number }) {
 function RearTunnelCore({ lowPower, progress }: { lowPower: boolean; progress: number }) {
   const materialRef = useRef<THREE.MeshBasicMaterial>(null)
   const activeSpokes = lowPower ? lowPowerRearSpokeIndices : rearSpokeIndices
+  const activeApertureSpokes = lowPower ? lowPowerApertureSpokes : apertureSpokes
 
   useFrame(({ clock }) => {
     if (materialRef.current) {
@@ -415,6 +466,7 @@ function RearTunnelCore({ lowPower, progress }: { lowPower: boolean; progress: n
 
   return (
     <group position={[1.35, 0.56, -24.5]}>
+      <pointLight position={[0, 0.1, 1.3]} intensity={13 + progress * 7} color="#f1efe6" distance={18} />
       <mesh>
         <torusGeometry args={[2.55, 0.045, 8, 96]} />
         <meshStandardMaterial color="#eee7d8" emissive="#4b3027" emissiveIntensity={0.65} metalness={0.92} roughness={0.34} />
@@ -433,6 +485,16 @@ function RearTunnelCore({ lowPower, progress }: { lowPower: boolean; progress: n
           <mesh key={`rear-spoke-${index}`} position={[Math.cos(angle) * 1.95, Math.sin(angle) * 1.95, 0]} rotation={[0, 0, angle]}>
             <boxGeometry args={[1.25, 0.018, 0.018]} />
             <meshBasicMaterial color={index % 4 === 0 ? "#8f8172" : "#332a25"} transparent opacity={0.72} />
+          </mesh>
+        )
+      })}
+      {activeApertureSpokes.map((index) => {
+        const angle = (index / apertureSpokes.length) * Math.PI * 2
+        const radius = index % 2 === 0 ? 3.05 : 3.42
+        return (
+          <mesh key={`aperture-spoke-${index}`} position={[Math.cos(angle) * radius * 0.5, Math.sin(angle) * radius * 0.5, -0.18]} rotation={[0, 0, angle]}>
+            <boxGeometry args={[radius, 0.012, 0.012]} />
+            <meshBasicMaterial color={index % 4 === 0 ? "#6f655a" : "#211a17"} transparent opacity={0.48} />
           </mesh>
         )
       })}
@@ -725,9 +787,19 @@ function ProjectSlabs() {
     <group position={[-0.4, 0.55, -8]}>
       {featuredPortfolioProjects.map((project, index) => (
         <group key={project.id} position={[-3.8 + index * 2.75, 0.15 + index * 0.18, -index * 2.15]} rotation={[0, -0.22, 0]}>
+          {slabCableIndices.map((cable) => (
+            <mesh key={`slab-cable-${project.id}-${cable}`} position={[-0.64 + cable * 0.42, 2.45, -0.02]}>
+              <boxGeometry args={[0.014, 3.6, 0.014]} />
+              <meshBasicMaterial color="#0b0a09" transparent opacity={0.78} />
+            </mesh>
+          ))}
           <mesh>
             <boxGeometry args={[1.75, 2.65, 0.08]} />
             <meshStandardMaterial color={index === 0 ? "#2b2a27" : "#171716"} metalness={0.75} roughness={0.52} />
+          </mesh>
+          <mesh position={[0, 0, 0.073]}>
+            <boxGeometry args={[1.9, 2.8, 0.018]} />
+            <meshBasicMaterial color={index === 0 ? "#f1eadb" : "#7a7064"} transparent opacity={index === 0 ? 0.13 : 0.07} />
           </mesh>
           <mesh position={[0, 0, 0.055]}>
             <planeGeometry args={[1.55, 2.42]} />
@@ -741,12 +813,16 @@ function ProjectSlabs() {
 }
 
 function CapabilityField() {
+  const nodePositions = portfolioCapabilities.map((capability, index) => {
+    const angle = (index / portfolioCapabilities.length) * Math.PI * 2
+    const x = Math.cos(angle) * 3.4
+    const z = Math.sin(angle) * 2.6
+    return { capability, index, x, z }
+  })
+
   return (
     <group position={[2.3, -0.2, -19]}>
-      {portfolioCapabilities.map((capability, index) => {
-        const angle = (index / portfolioCapabilities.length) * Math.PI * 2
-        const x = Math.cos(angle) * 3.4
-        const z = Math.sin(angle) * 2.6
+      {nodePositions.map(({ capability, index, x, z }) => {
         return (
           <group key={capability.id} position={[x, 0.1 + (index % 2) * 0.45, z]}>
             <mesh>
@@ -758,6 +834,16 @@ function CapabilityField() {
               <meshStandardMaterial color="#7f1014" emissive="#5f0609" emissiveIntensity={1.2} />
             </mesh>
           </group>
+        )
+      })}
+      {nodePositions.map(({ capability, x, z }) => {
+        const length = Math.sqrt(x * x + z * z)
+        const angle = Math.atan2(z, x)
+        return (
+          <mesh key={`capability-link-${capability.id}`} position={[x / 2, 0.62, z / 2]} rotation={[0, -angle, 0]}>
+            <boxGeometry args={[length, 0.018, 0.018]} />
+            <meshBasicMaterial color="#918578" transparent opacity={0.22} />
+          </mesh>
         )
       })}
       <mesh position={[0, 0.95, 0]}>
@@ -780,6 +866,28 @@ function ContactBeacon() {
         <cylinderGeometry args={[1.35, 1.35, 0.08, 48]} />
         <meshStandardMaterial color="#151210" metalness={0.8} roughness={0.4} />
       </mesh>
+      <mesh position={[0, -0.08, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <ringGeometry args={[1.55, 2.15, 64]} />
+        <meshBasicMaterial color="#b51218" transparent opacity={0.28} side={THREE.DoubleSide} />
+      </mesh>
+      {beaconSteps.map((step) => (
+        <mesh key={`beacon-step-${step}`} position={[0, -0.18 - step * 0.05, 1.15 + step * 0.58]}>
+          <boxGeometry args={[3.1 + step * 0.5, 0.04, 0.26]} />
+          <meshStandardMaterial color="#12100e" emissive={step % 2 === 0 ? "#170707" : "#050303"} emissiveIntensity={0.22} metalness={0.84} roughness={0.44} />
+        </mesh>
+      ))}
+      {[-1, 1].map((side) => (
+        <group key={`beacon-side-${side}`} position={[side * 2.6, 0.1, 0.2]}>
+          <mesh position={[0, 0.8, 0]}>
+            <boxGeometry args={[0.1, 1.9, 0.1]} />
+            <meshStandardMaterial color="#100e0d" emissive="#070303" emissiveIntensity={0.24} metalness={0.9} roughness={0.44} />
+          </mesh>
+          <mesh position={[0, 1.55, 0.04]}>
+            <boxGeometry args={[0.05, 0.28, 0.04]} />
+            <meshBasicMaterial color="#ff252b" transparent opacity={0.72} />
+          </mesh>
+        </group>
+      ))}
     </group>
   )
 }

--- a/components/industrial-home-experience.tsx
+++ b/components/industrial-home-experience.tsx
@@ -54,6 +54,13 @@ const gantryLadderRungs = Array.from({ length: 10 }, (_, index) => index)
 const apertureSpokes = Array.from({ length: 28 }, (_, index) => index)
 const lowPowerApertureSpokes = apertureSpokes.filter((index) => index % 2 === 0)
 const verticalLightStackRows = Array.from({ length: 9 }, (_, index) => index)
+const lowPowerVerticalLightStackRows = verticalLightStackRows.filter((index) => index % 2 === 0)
+const industrialLightStacks = [
+  [-6.3, 1.2, -9.2, 0.18],
+  [6.8, 1.6, -8.4, -0.18],
+  [7.75, 2.4, -14.6, -0.28],
+  [-7.4, 2.2, -16.2, 0.22],
+] as const
 const slabCableIndices = Array.from({ length: 4 }, (_, index) => index)
 const beaconSteps = Array.from({ length: 5 }, (_, index) => index)
 const smokePlumes = [
@@ -296,17 +303,11 @@ function HeroSetPieces({ lowPower, progress }: { lowPower: boolean; progress: nu
 }
 
 function IndustrialLightStacks({ lowPower, progress }: { lowPower: boolean; progress: number }) {
-  const rows = lowPower ? verticalLightStackRows.filter((index) => index % 2 === 0) : verticalLightStackRows
-  const stacks = [
-    [-6.3, 1.2, -9.2, 0.18],
-    [6.8, 1.6, -8.4, -0.18],
-    [7.75, 2.4, -14.6, -0.28],
-    [-7.4, 2.2, -16.2, 0.22],
-  ] as const
+  const rows = useMemo(() => (lowPower ? lowPowerVerticalLightStackRows : verticalLightStackRows), [lowPower])
 
   return (
     <group>
-      {stacks.map(([x, y, z, rotY], stackIndex) => (
+      {industrialLightStacks.map(([x, y, z, rotY], stackIndex) => (
         <group key={`industrial-light-stack-${stackIndex}`} position={[x, y, z]} rotation={[0, rotY, 0]}>
           <mesh position={[0, 1.5, 0]}>
             <boxGeometry args={[0.16, 4.1, 0.12]} />
@@ -813,12 +814,23 @@ function ProjectSlabs() {
 }
 
 function CapabilityField() {
-  const nodePositions = portfolioCapabilities.map((capability, index) => {
-    const angle = (index / portfolioCapabilities.length) * Math.PI * 2
-    const x = Math.cos(angle) * 3.4
-    const z = Math.sin(angle) * 2.6
-    return { capability, index, x, z }
-  })
+  const nodePositions = useMemo(
+    () =>
+      portfolioCapabilities.map((capability, index) => {
+        const angle = (index / portfolioCapabilities.length) * Math.PI * 2
+        const x = Math.cos(angle) * 3.4
+        const z = Math.sin(angle) * 2.6
+        return {
+          capability,
+          index,
+          x,
+          z,
+          linkAngle: Math.atan2(z, x),
+          linkLength: Math.sqrt(x * x + z * z),
+        }
+      }),
+    [],
+  )
 
   return (
     <group position={[2.3, -0.2, -19]}>
@@ -836,12 +848,10 @@ function CapabilityField() {
           </group>
         )
       })}
-      {nodePositions.map(({ capability, x, z }) => {
-        const length = Math.sqrt(x * x + z * z)
-        const angle = Math.atan2(z, x)
+      {nodePositions.map(({ capability, linkAngle, linkLength, x, z }) => {
         return (
-          <mesh key={`capability-link-${capability.id}`} position={[x / 2, 0.62, z / 2]} rotation={[0, -angle, 0]}>
-            <boxGeometry args={[length, 0.018, 0.018]} />
+          <mesh key={`capability-link-${capability.id}`} position={[x / 2, 0.62, z / 2]} rotation={[0, -linkAngle, 0]}>
+            <boxGeometry args={[linkLength, 0.018, 0.018]} />
             <meshBasicMaterial color="#918578" transparent opacity={0.22} />
           </mesh>
         )


### PR DESCRIPTION
## Summary
- tighten the homepage hero lockup toward the accepted industrial concept proportions
- add denser side-tower silhouettes, red light stacks, stronger runway/floor depth, and brighter tunnel aperture treatment
- deepen scroll sections with suspended slab cables, capability node wiring, and a central red-beam contact outro

## Validation
- pnpm lint
- pnpm type-check
- pnpm test:unit
- pnpm build
- Browser/IAB dev QA: desktop home, work, systems, contact, and mobile home render with no console errors
- Browser/IAB production smoke: / renders one canvas; /#contact activates the contact state; /projects renders zero canvases

## Concept Reference
- /Users/michaelchaves/.codex/generated_images/019e18cd-9be8-70d3-9312-cb180cb3e4d4/ig_052ad6891b4fb974016a02843c89e88196a90dfd426e373376.png