### PR TITLE
Restore project image color on hover

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1109,7 +1109,7 @@ html {
 .industrial-card:focus-visible .industrial-project-image,
 .industrial-card-media:hover .industrial-project-image,
 .industrial-card-media:focus-visible .industrial-project-image {
-  filter: grayscale(0) saturate(1.08) contrast(1.02) !important;
+  filter: grayscale(0) saturate(1.08) contrast(1.02);
   transform: scale(1.025);
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1101,6 +1101,18 @@ html {
   background: #080808;
 }
 
+.industrial-project-image {
+  transition: filter 220ms ease, transform 220ms ease;
+}
+
+.industrial-card:hover .industrial-project-image,
+.industrial-card:focus-visible .industrial-project-image,
+.industrial-card-media:hover .industrial-project-image,
+.industrial-card-media:focus-visible .industrial-project-image {
+  filter: grayscale(0) saturate(1.08) contrast(1.02) !important;
+  transform: scale(1.025);
+}
+
 .industrial-card-media::after {
   content: "";
   position: absolute;

--- a/app/projects/[id]/ProjectPageClient.tsx
+++ b/app/projects/[id]/ProjectPageClient.tsx
@@ -132,7 +132,7 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
             src={project.image || `/api/placeholder?width=1200&height=700&text=${encodeURIComponent(project.title)}`}
             alt={project.title}
             fill
-            className="object-cover grayscale"
+            className="industrial-project-image object-cover grayscale"
             sizes="(min-width: 1024px) 50vw, 100vw"
             priority
           />
@@ -165,7 +165,7 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
               onClick={() => setSelectedIndex(index + 1)}
               aria-label={`Open gallery image ${index + 1}`}
             >
-              <Image src={img} alt={`${project.title} gallery image ${index + 1}`} fill className="object-cover grayscale" sizes="33vw" />
+              <Image src={img} alt={`${project.title} gallery image ${index + 1}`} fill className="industrial-project-image object-cover grayscale" sizes="33vw" />
             </button>
           ))}
         </section>

--- a/app/projects/[id]/ProjectPageClient.tsx
+++ b/app/projects/[id]/ProjectPageClient.tsx
@@ -165,7 +165,7 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
               onClick={() => setSelectedIndex(index + 1)}
               aria-label={`Open gallery image ${index + 1}`}
             >
-              <Image src={img} alt={`${project.title} gallery image ${index + 1}`} fill className="industrial-project-image object-cover grayscale" sizes="33vw" />
+              <Image src={img} alt={`${project.title} gallery image ${index + 1}`} fill className="industrial-project-image object-cover grayscale" sizes="(min-width: 768px) 33vw, 100vw" />
             </button>
           ))}
         </section>

--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -17,7 +17,7 @@ export function ProjectCard({ id, title, description, image, technologies, prior
           }
           alt={title}
           fill
-          className="object-cover grayscale"
+          className="industrial-project-image object-cover grayscale"
           sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
           priority={priority}
         />


### PR DESCRIPTION
## Summary
- keep project imagery grayscale by default while restoring full color on hover/focus
- apply the shared hover treatment to project index cards, project detail hero images, and gallery thumbnails

## Validation
- pnpm lint
- pnpm type-check
- pnpm test:unit
- pnpm build
- Browser/IAB smoke: /projects loads with no console errors and project images render with the shared hover-color class