### PR TITLE
Make selected work slabs feel suspended

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -763,8 +763,10 @@ html {
 .industrial-project-list {
   display: grid;
   grid-template-columns: minmax(13rem, 1.35fr) repeat(3, minmax(8.5rem, 1fr));
-  gap: 1rem;
-  perspective: 1200px;
+  gap: clamp(0.85rem, 1.5vw, 1.25rem);
+  perspective: 1500px;
+  perspective-origin: 38% 42%;
+  transform-style: preserve-3d;
 }
 
 .industrial-project-slab,
@@ -781,54 +783,103 @@ html {
 }
 
 .industrial-project-slab {
+  --slab-rotate-y: -8deg;
+  --slab-rotate-x: 0deg;
+  --slab-translate-y: 0rem;
+  --slab-depth: 1.1rem;
   position: relative;
   display: flex;
   min-height: 26rem;
   flex-direction: column;
   justify-content: space-between;
-  padding: 1rem;
+  padding: 1.1rem;
   color: #eee7d8;
-  overflow: hidden;
-  transform: rotateY(-8deg) translateY(0);
+  overflow: visible;
+  isolation: isolate;
+  transform: rotateY(var(--slab-rotate-y)) rotateX(var(--slab-rotate-x)) translateY(var(--slab-translate-y)) translateZ(0);
   transform-style: preserve-3d;
+  transform-origin: 50% 14%;
+  transition: transform 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
+  will-change: transform;
+  box-shadow:
+    inset 0 0 26px rgba(255,255,255,0.035),
+    inset -18px 0 34px rgba(0,0,0,0.42),
+    calc(var(--slab-depth) * -0.55) calc(var(--slab-depth) * 0.7) 0 rgba(20,16,14,0.74),
+    0 34px 80px rgba(0,0,0,0.44);
 }
 
 .industrial-project-slab:nth-child(1) {
-  transform: rotateY(-11deg) translateY(1rem);
+  --slab-rotate-y: -15deg;
+  --slab-rotate-x: 1.4deg;
+  --slab-translate-y: 1.1rem;
+  --slab-depth: 1.35rem;
 }
 
 .industrial-project-slab:nth-child(2) {
-  transform: rotateY(-6deg) translateY(-0.5rem);
+  --slab-rotate-y: -9deg;
+  --slab-rotate-x: -0.7deg;
+  --slab-translate-y: -0.55rem;
 }
 
 .industrial-project-slab:nth-child(3) {
-  transform: rotateY(-4deg) translateY(0.7rem);
+  --slab-rotate-y: -5deg;
+  --slab-rotate-x: 0.5deg;
+  --slab-translate-y: 0.65rem;
 }
 
 .industrial-project-slab:nth-child(4) {
-  transform: rotateY(-3deg) translateY(1.6rem);
+  --slab-rotate-y: -2deg;
+  --slab-rotate-x: 1.2deg;
+  --slab-translate-y: 1.55rem;
+}
+
+.industrial-project-slab:hover,
+.industrial-project-slab:focus-visible {
+  border-color: rgba(238, 231, 216, 0.36);
+  transform: rotateY(calc(var(--slab-rotate-y) - 2deg)) rotateX(calc(var(--slab-rotate-x) - 0.8deg)) translateY(calc(var(--slab-translate-y) - 0.35rem)) translateZ(2.2rem);
+  box-shadow:
+    inset 0 0 28px rgba(255,255,255,0.055),
+    inset -18px 0 34px rgba(0,0,0,0.42),
+    calc(var(--slab-depth) * -0.55) calc(var(--slab-depth) * 0.7) 0 rgba(24,18,15,0.82),
+    0 0 34px rgba(181,18,24,0.22),
+    0 38px 92px rgba(0,0,0,0.58);
 }
 
 .industrial-project-slab::before {
   content: "";
   position: absolute;
-  inset: 0.7rem;
-  border: 1px solid rgba(238,231,216,0.13);
+  inset: 0.75rem;
+  border: 1px solid rgba(238,231,216,0.16);
   background:
     repeating-linear-gradient(0deg, rgba(238,231,216,0.035) 0 1px, transparent 1px 5px),
-    radial-gradient(circle at 22% 16%, rgba(238,231,216,0.12), transparent 8rem);
-  opacity: 0.72;
+    radial-gradient(circle at 22% 16%, rgba(238,231,216,0.14), transparent 8rem),
+    linear-gradient(115deg, transparent 0 42%, rgba(238,231,216,0.08) 43%, transparent 46% 100%);
+  opacity: 0.78;
 }
 
 .industrial-project-slab::after {
   content: "";
   position: absolute;
-  top: -2rem;
-  left: 50%;
-  width: 1px;
-  height: 3.7rem;
-  background: linear-gradient(#eee7d8, rgba(238,231,216,0));
-  opacity: 0.3;
+  top: -4.2rem;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(90deg, transparent calc(50% - 3.2rem), rgba(238,231,216,0.42) calc(50% - 3.16rem), transparent calc(50% - 3.1rem) calc(50% + 3.1rem), rgba(238,231,216,0.38) calc(50% + 3.16rem), transparent calc(50% + 3.22rem)),
+    linear-gradient(90deg, transparent calc(100% - 0.65rem), rgba(238,231,216,0.16) calc(100% - 0.62rem), rgba(0,0,0,0.55) 100%),
+    linear-gradient(180deg, rgba(238,231,216,0.16), transparent 17%);
+  background-repeat: no-repeat;
+  background-size: 100% 4.9rem, 100% calc(100% - 4.2rem), 100% calc(100% - 4.2rem);
+  background-position: 0 0, 0 4.2rem, 0 4.2rem;
+  opacity: 0.72;
+  transform: translateZ(0.2rem);
+  filter: drop-shadow(0 1rem 1.2rem rgba(0,0,0,0.42));
+}
+
+.industrial-project-slab:hover::after,
+.industrial-project-slab:focus-visible::after {
+  opacity: 0.92;
 }
 
 .industrial-project-slab > * {
@@ -1170,6 +1221,9 @@ html {
   .industrial-project-slab:nth-child(2),
   .industrial-project-slab:nth-child(3),
   .industrial-project-slab:nth-child(4) {
+    --slab-rotate-y: 0deg;
+    --slab-rotate-x: 0deg;
+    --slab-translate-y: 0rem;
     transform: none;
   }
 
@@ -1267,6 +1321,12 @@ html {
     animation-iteration-count: 1 !important;
     scroll-behavior: auto !important;
     transition-duration: 0.001ms !important;
+  }
+
+  .industrial-project-slab,
+  .industrial-project-slab:hover,
+  .industrial-project-slab:focus-visible {
+    transform: rotateY(var(--slab-rotate-y)) rotateX(var(--slab-rotate-x)) translateY(var(--slab-translate-y));
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -866,7 +866,14 @@ html {
   left: 0;
   pointer-events: none;
   background:
-    linear-gradient(90deg, transparent calc(50% - 3.2rem), rgba(238,231,216,0.42) calc(50% - 3.16rem), transparent calc(50% - 3.1rem) calc(50% + 3.1rem), rgba(238,231,216,0.38) calc(50% + 3.16rem), transparent calc(50% + 3.22rem)),
+    linear-gradient(
+      90deg,
+      transparent calc(50% - 3.2rem),
+      rgba(238,231,216,0.42) calc(50% - 3.16rem),
+      transparent calc(50% - 3.1rem) calc(50% + 3.1rem),
+      rgba(238,231,216,0.38) calc(50% + 3.16rem),
+      transparent calc(50% + 3.22rem)
+    ),
     linear-gradient(90deg, transparent calc(100% - 0.65rem), rgba(238,231,216,0.16) calc(100% - 0.62rem), rgba(0,0,0,0.55) 100%),
     linear-gradient(180deg, rgba(238,231,216,0.16), transparent 17%);
   background-repeat: no-repeat;


### PR DESCRIPTION
## Summary
- deepen the Selected Work slab perspective so the project panels read as suspended 3D objects
- add visible external hanging lines, side-edge depth, stronger light streaks, and hover/focus lift
- keep readable project text in DOM while matching the concept art direction more closely

## Test Plan
- pnpm lint
- pnpm type-check
- pnpm test:unit
- pnpm build
- Browser QA on http://localhost:3000/#work: page identity, visible Selected Work section, 4 slabs rendered, screenshot comparison against concept art