### PR TITLE
[codex] Add full-page WebGL homepage background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -381,6 +381,40 @@ textarea {
   animation: home-scan-warp 5.5s steps(18) infinite;
 }
 
+.home-webgl-stage .home-corruption-overlay,
+.home-webgl-stage .home-scan-distortion {
+  position: absolute;
+}
+
+.home-webgl-vignette {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background:
+    radial-gradient(80% 42% at 50% 8%, rgba(0, 255, 140, 0.08), transparent 68%),
+    linear-gradient(180deg, rgba(0, 0, 0, 0.04) 0%, rgba(0, 0, 0, 0.42) 54%, rgba(0, 0, 0, 0.72) 100%),
+    radial-gradient(100% 80% at 50% 50%, transparent 35%, rgba(0, 0, 0, 0.62) 100%);
+}
+
+.home-webgl-background canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.home-immersive-page .terminal-window,
+.home-immersive-page .card-hover {
+  background-color: rgba(0, 0, 0, 0.74);
+  backdrop-filter: blur(8px);
+}
+
+.home-immersive-page .card-hover {
+  box-shadow:
+    inset 0 0 28px rgba(0, 255, 140, 0.04),
+    0 14px 42px rgba(0, 0, 0, 0.34);
+}
+
 .infection-badge {
   position: absolute;
   top: -12px;
@@ -414,4 +448,17 @@ textarea {
   0% { transform: translateY(0); opacity: 0.15; }
   50% { transform: translateY(1px); opacity: 0.24; }
   100% { transform: translateY(0); opacity: 0.15; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-corruption-overlay,
+  .home-scan-distortion,
+  .infection-badge,
+  .neon-separator {
+    animation: none;
+  }
+
+  .home-scan-distortion {
+    opacity: 0.12;
+  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,12 +14,7 @@ const HeroBackground = dynamic(
   () => import("@/components/hero-background").then((m) => m.HeroBackground),
   {
     ssr: false,
-    loading: () => (
-      <div
-        className="absolute inset-0 -z-10 overflow-hidden"
-        aria-hidden="true"
-      />
-    ),
+    loading: () => null,
   }
 )
 import { RecentHighlights } from "@/components/recent-highlights"
@@ -197,13 +192,12 @@ export default function Home() {
   ];
 
   return (
-    <div className="space-y-16 relative">
-      <div className="home-corruption-overlay" aria-hidden="true" />
-      <div className="home-scan-distortion" aria-hidden="true" />
+    <div className="home-immersive-page relative isolate">
+      <HeroBackground />
       <h1 className="sr-only">Mike Chaves - UX Designer & Developer</h1>
 
-      <section className="py-12 relative">
-        <HeroBackground />
+      <div className="home-content-layer relative z-10 space-y-16">
+      <section className="relative flex min-h-[42vh] flex-col justify-center py-12 sm:py-16">
         <Terminal
           text="$ Forward-deployed AI/product operator for teams shipping at enterprise scale."
           typingSpeed={40}
@@ -352,6 +346,7 @@ export default function Home() {
       </section>
 
       <RecentHighlights />
+      </div>
     </div>
   );
 }

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -5,7 +5,7 @@ import { faXTwitter } from "@fortawesome/free-brands-svg-icons"
 
 export function Footer() {
   return (
-    <footer className="border-t border-border/40 py-6">
+    <footer className="relative z-10 border-t border-border/40 bg-black/80 py-6 backdrop-blur-sm">
       <div className="container mx-auto px-4">
         <div className="flex flex-col md:flex-row justify-between items-center">
           <div className="mb-4 md:mb-0">

--- a/components/hero-background.tsx
+++ b/components/hero-background.tsx
@@ -261,13 +261,19 @@ export function HeroBackground() {
       grid.rotation.z = lowerDepth * 0.04
     }
 
-    window.addEventListener("mousemove", handleMouseMove)
-    window.addEventListener("scroll", applyScrollState, { passive: true })
-
     const renderStill = () => {
       applyScrollState()
       renderer.render(scene, camera)
     }
+
+    const handleScroll = () => {
+      if (reducedMotionRef.current) {
+        renderStill()
+      }
+    }
+
+    window.addEventListener("mousemove", handleMouseMove)
+    window.addEventListener("scroll", handleScroll, { passive: true })
 
     const animate = () => {
       frameRef.current = requestAnimationFrame(animate)
@@ -319,7 +325,7 @@ export function HeroBackground() {
 
     return () => {
       window.removeEventListener("mousemove", handleMouseMove)
-      window.removeEventListener("scroll", applyScrollState)
+      window.removeEventListener("scroll", handleScroll)
       cancelAnimationFrame(frameRef.current)
 
       if (rendererRef.current) {

--- a/components/hero-background.tsx
+++ b/components/hero-background.tsx
@@ -1,10 +1,21 @@
 "use client"
 
-import { useRef, useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useViewportSize } from "@/hooks/use-viewport-size"
+import { createPortal } from "react-dom"
 import * as THREE from "three"
 
-// Import THREE from the same source to avoid duplicate instances
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max)
+
+function createSeededRandom(seed: number) {
+  let value = seed
+
+  return () => {
+    value = (value * 1664525 + 1013904223) % 4294967296
+    return value / 4294967296
+  }
+}
+
 export function HeroBackground() {
   const containerRef = useRef<HTMLDivElement>(null)
   const sceneRef = useRef<THREE.Scene | null>(null)
@@ -12,13 +23,21 @@ export function HeroBackground() {
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null)
   const particlesRef = useRef<THREE.Points | null>(null)
   const gridRef = useRef<THREE.LineSegments | null>(null)
+  const gridMaterialRef = useRef<THREE.LineBasicMaterial | null>(null)
+  const particleMaterialRef = useRef<THREE.ShaderMaterial | null>(null)
   const frameRef = useRef<number>(0)
-  const mousePosition = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
+  const mousePosition = useRef({ x: 0, y: 0 })
   const viewportRef = useRef({ width: 1, height: 1 })
+  const reducedMotionRef = useRef(false)
+  const [isMounted, setIsMounted] = useState(false)
   const [isMobile, setIsMobile] = useState(() =>
     typeof window !== "undefined" ? window.innerWidth < 768 : false,
   )
   const viewport = useViewportSize()
+
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
 
   useEffect(() => {
     viewportRef.current = {
@@ -29,121 +48,108 @@ export function HeroBackground() {
   }, [viewport.height, viewport.width])
 
   useEffect(() => {
+    if (!isMounted) return
     if (!containerRef.current) return
-
-    // Prevent double initialization in development (React Strict Mode)
     if (sceneRef.current) return
 
-    // Initialize scene
+    const random = createSeededRandom(isMobile ? 2407 : 8713)
+    reducedMotionRef.current = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+
     const scene = new THREE.Scene()
     sceneRef.current = scene
 
-    // Initialize camera
     const camera = new THREE.PerspectiveCamera(
-      60,
+      58,
       viewportRef.current.width / viewportRef.current.height,
       0.1,
       1000,
     )
-    camera.position.z = 20
+    camera.position.set(0, 0, 26)
     cameraRef.current = camera
 
-    // Initialize renderer
-    const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true })
+    const renderer = new THREE.WebGLRenderer({
+      alpha: true,
+      antialias: !isMobile,
+      powerPreference: "high-performance",
+    })
     renderer.setSize(viewportRef.current.width, viewportRef.current.height)
-    renderer.setClearColor(0x000000, 0) // Transparent background
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, isMobile ? 1.15 : 1.5))
+    renderer.setClearColor(0x000000, 0)
+    renderer.domElement.setAttribute("aria-hidden", "true")
+
     const container = containerRef.current
     container.appendChild(renderer.domElement)
     rendererRef.current = renderer
 
-    // Create cyberpunk grid
-    const gridSize = 40
-    const gridDivisions = isMobile ? 10 : 20 // Fewer grid lines on mobile
+    const gridSize = isMobile ? 46 : 68
+    const gridDivisions = isMobile ? 12 : 24
     const gridMaterial = new THREE.LineBasicMaterial({
       color: 0x00ff8c,
       transparent: true,
-      opacity: isMobile ? 0.08 : 0.1, // Slightly more subtle on mobile
+      opacity: isMobile ? 0.07 : 0.11,
     })
+    gridMaterialRef.current = gridMaterial
 
     const gridGeometry = new THREE.BufferGeometry()
-    const gridPositions = []
-
-    // Create grid lines
+    const gridPositions: number[] = []
     const step = gridSize / gridDivisions
     const halfGrid = gridSize / 2
 
-    // Create horizontal lines
     for (let i = 0; i <= gridDivisions; i++) {
-      const y = i * step - halfGrid
-      gridPositions.push(-halfGrid, y, 0)
-      gridPositions.push(halfGrid, y, 0)
-    }
-
-    // Create vertical lines
-    for (let i = 0; i <= gridDivisions; i++) {
-      const x = i * step - halfGrid
-      gridPositions.push(x, -halfGrid, 0)
-      gridPositions.push(x, halfGrid, 0)
+      const offset = i * step - halfGrid
+      gridPositions.push(-halfGrid, offset, 0, halfGrid, offset, 0)
+      gridPositions.push(offset, -halfGrid, 0, offset, halfGrid, 0)
     }
 
     gridGeometry.setAttribute("position", new THREE.Float32BufferAttribute(gridPositions, 3))
     const grid = new THREE.LineSegments(gridGeometry, gridMaterial)
-    grid.rotation.x = Math.PI / 8 // Slight tilt for perspective
-    grid.position.z = -10
+    grid.rotation.x = Math.PI / 5
+    grid.position.set(0, -3.5, -18)
     scene.add(grid)
     gridRef.current = grid
 
-    // Create particles - reduce count on mobile
-    const particleCount = isMobile ? 200 : 600
+    const particleCount = reducedMotionRef.current ? (isMobile ? 90 : 220) : isMobile ? 170 : 520
     const particles = new THREE.BufferGeometry()
     const positions = new Float32Array(particleCount * 3)
     const colors = new Float32Array(particleCount * 3)
     const sizes = new Float32Array(particleCount)
+    const baseSizes = new Float32Array(particleCount)
     const speeds = new Float32Array(particleCount)
     const rotations = new Float32Array(particleCount)
     const types = new Float32Array(particleCount)
-
     const color = new THREE.Color()
 
-    // Adjust particle distribution for mobile
-    const xSpread = isMobile ? 20 : 30
-    const ySpread = isMobile ? 15 : 20
-    const zSpread = isMobile ? 10 : 20
-
-    // Adjust particle size for mobile
-    const baseSize = isMobile ? 1.5 : 3
-    const sizeVariation = isMobile ? 0.5 : 1.5
+    const xSpread = isMobile ? 26 : 42
+    const ySpread = isMobile ? 24 : 34
+    const zNear = isMobile ? 6 : 8
+    const zDepth = isMobile ? 24 : 34
+    const baseSize = isMobile ? 1.3 : 2.25
+    const sizeVariation = isMobile ? 0.8 : 1.6
 
     for (let i = 0; i < particleCount; i++) {
-      // Position - create a more layered depth effect
-      positions[i * 3] = (Math.random() - 0.5) * xSpread // x
-      positions[i * 3 + 1] = (Math.random() - 0.5) * ySpread // y
-      positions[i * 3 + 2] = (Math.random() - 0.5) * zSpread // z - varying depths
+      const i3 = i * 3
 
-      // Color - mostly our cyberpunk green with occasional variations
-      if (Math.random() > 0.85) {
-        // Occasional blue or purple particles
-        color.setHSL(0.6 + Math.random() * 0.2, 1.0, 0.5 + Math.random() * 0.3)
+      positions[i3] = (random() - 0.5) * xSpread
+      positions[i3 + 1] = (random() - 0.5) * ySpread
+      positions[i3 + 2] = zNear - random() * zDepth
+
+      const accentRoll = random()
+      if (accentRoll > 0.93) {
+        color.setHSL(0.82, 0.85, 0.55 + random() * 0.18)
+      } else if (accentRoll > 0.84) {
+        color.setHSL(0.56, 0.85, 0.5 + random() * 0.18)
       } else {
-        // Mostly green particles with varying brightness
-        color.setRGB(0, 1 * (0.5 + Math.random() * 0.5), 0.55 * (0.5 + Math.random() * 0.5))
+        color.setRGB(0.05 + random() * 0.1, 0.62 + random() * 0.38, 0.34 + random() * 0.26)
       }
 
-      colors[i * 3] = color.r
-      colors[i * 3 + 1] = color.g
-      colors[i * 3 + 2] = color.b
-
-      // Size - varying particle sizes, smaller on mobile
-      sizes[i] = Math.random() * sizeVariation + baseSize
-
-      // Speed - varying particle speeds
-      speeds[i] = Math.random() * 0.02 + 0.005
-
-      // Rotation - random initial rotation
-      rotations[i] = Math.random() * Math.PI * 2
-
-      // Type - different particle shapes (0-3)
-      types[i] = Math.floor(Math.random() * 4)
+      colors[i3] = color.r
+      colors[i3 + 1] = color.g
+      colors[i3 + 2] = color.b
+      baseSizes[i] = random() * sizeVariation + baseSize
+      sizes[i] = baseSizes[i]
+      speeds[i] = random() * 0.018 + 0.004
+      rotations[i] = random() * Math.PI * 2
+      types[i] = Math.floor(random() * 4)
     }
 
     particles.setAttribute("position", new THREE.BufferAttribute(positions, 3))
@@ -152,31 +158,29 @@ export function HeroBackground() {
     particles.setAttribute("rotation", new THREE.BufferAttribute(rotations, 1))
     particles.setAttribute("type", new THREE.BufferAttribute(types, 1))
 
-    // Create custom shader material for cyberpunk particles
     const particleMaterial = new THREE.ShaderMaterial({
       uniforms: {
-        time: { value: 0 },
-        pixelRatio: { value: window.devicePixelRatio },
+        pixelRatio: { value: Math.min(window.devicePixelRatio || 1, isMobile ? 1.15 : 1.5) },
+        globalOpacity: { value: isMobile ? 0.42 : 0.64 },
       },
       vertexShader: `
         attribute float size;
         attribute float rotation;
         attribute float type;
-        
+
         varying vec3 vColor;
         varying float vRotation;
         varying float vType;
-        
-        uniform float time;
+
         uniform float pixelRatio;
-        
+
         void main() {
           vColor = color;
           vRotation = rotation;
           vType = type;
-          
+
           vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
-          gl_PointSize = size * pixelRatio * (300.0 / -mvPosition.z);
+          gl_PointSize = size * pixelRatio * (300.0 / max(1.0, -mvPosition.z));
           gl_Position = projectionMatrix * mvPosition;
         }
       `,
@@ -184,53 +188,41 @@ export function HeroBackground() {
         varying vec3 vColor;
         varying float vRotation;
         varying float vType;
-        
+
+        uniform float globalOpacity;
+
         void main() {
-          // Center the coordinate system
           vec2 center = vec2(0.5, 0.5);
           vec2 uv = gl_PointCoord.xy - center;
-          
-          // Apply rotation
+
           float s = sin(vRotation);
           float c = cos(vRotation);
           uv = vec2(uv.x * c - uv.y * s, uv.x * s + uv.y * c);
-          
-          // Determine shape based on type
+
           float alpha = 0.0;
-          
-          // Type 0: Square/Rectangle (digital pixel)
+
           if (vType < 1.0) {
             if (abs(uv.x) < 0.3 && abs(uv.y) < 0.3) {
-              alpha = 0.6;
+              alpha = 0.65;
             }
-          } 
-          // Type 1: Binary (1/0)
-          else if (vType < 2.0) {
-            // Create a "1" shape
+          } else if (vType < 2.0) {
             if (abs(uv.x) < 0.05 && uv.y < 0.25 && uv.y > -0.25) {
               alpha = 0.7;
             }
-          }
-          // Type 2: Triangle
-          else if (vType < 3.0) {
+          } else if (vType < 3.0) {
             vec2 p = abs(uv);
             if (p.x + p.y < 0.4) {
-              alpha = 0.6;
+              alpha = 0.58;
             }
-          }
-          // Type 3: Plus/Cross
-          else {
+          } else {
             if ((abs(uv.x) < 0.1 && abs(uv.y) < 0.3) || (abs(uv.x) < 0.3 && abs(uv.y) < 0.1)) {
-              alpha = 0.7;
+              alpha = 0.68;
             }
           }
-          
-          // Add a subtle glow effect
-          vec3 glow = vColor * 0.3;
+
+          vec3 glow = vColor * 0.28;
           vec3 finalColor = mix(glow, vColor, alpha > 0.0 ? 1.0 : 0.0);
-          
-          // Reduce opacity on mobile
-          gl_FragColor = vec4(finalColor, alpha * ${isMobile ? "0.5" : "0.7"});
+          gl_FragColor = vec4(finalColor, alpha * globalOpacity);
         }
       `,
       transparent: true,
@@ -238,122 +230,148 @@ export function HeroBackground() {
       blending: THREE.AdditiveBlending,
       vertexColors: true,
     })
+    particleMaterialRef.current = particleMaterial
 
-    // Create point cloud
     const pointCloud = new THREE.Points(particles, particleMaterial)
     scene.add(pointCloud)
     particlesRef.current = pointCloud
 
-    // Track mouse movement for subtle interactivity
     const handleMouseMove = (event: MouseEvent) => {
       mousePosition.current.x = (event.clientX / viewportRef.current.width) * 2 - 1
       mousePosition.current.y = -(event.clientY / viewportRef.current.height) * 2 + 1
     }
 
-    window.addEventListener("mousemove", handleMouseMove)
+    const applyScrollState = () => {
+      const viewportHeight = Math.max(viewportRef.current.height, 1)
+      const scrollZone = clamp(window.scrollY / viewportHeight, 0, 4)
+      const lowerPageCalm = clamp(scrollZone / 2.8, 0, 1)
+      const heroIntensity = 1 - lowerPageCalm * (isMobile ? 0.48 : 0.58)
+      const lowerDepth = clamp(scrollZone / 3.4, 0, 1)
 
-    // Animation function
+      particleMaterial.uniforms.globalOpacity.value = (isMobile ? 0.4 : 0.62) * heroIntensity
+      gridMaterial.opacity = (isMobile ? 0.065 : 0.105) * heroIntensity + 0.018
+
+      camera.position.y = -lowerDepth * 2.2
+      camera.position.z = 26 + lowerDepth * 3.5
+      camera.rotation.z = mousePosition.current.x * 0.01
+
+      pointCloud.position.y = lowerDepth * 1.4
+      pointCloud.rotation.z = -lowerDepth * 0.07
+      grid.position.y = -3.5 + lowerDepth * 1.8
+      grid.rotation.z = lowerDepth * 0.04
+    }
+
+    window.addEventListener("mousemove", handleMouseMove)
+    window.addEventListener("scroll", applyScrollState, { passive: true })
+
+    const renderStill = () => {
+      applyScrollState()
+      renderer.render(scene, camera)
+    }
+
     const animate = () => {
       frameRef.current = requestAnimationFrame(animate)
 
-      const time = Date.now() * 0.001
+      if (document.hidden) return
 
-      if (particleMaterial.uniforms) {
-        particleMaterial.uniforms.time.value = time
-      }
+      const time = performance.now() * 0.001
+      applyScrollState()
 
-      if (particlesRef.current) {
-        // Subtle rotation influenced by mouse position
-        particlesRef.current.rotation.y = time * 0.05 + mousePosition.current.x * 0.1
-        particlesRef.current.rotation.x = mousePosition.current.y * 0.1
+      pointCloud.rotation.y = time * 0.045 + mousePosition.current.x * 0.08
+      pointCloud.rotation.x = mousePosition.current.y * 0.08
 
-        // Update particle positions for a flowing effect
-        const positions = particlesRef.current.geometry.attributes.position.array as Float32Array
-        const sizes = particlesRef.current.geometry.attributes.size.array as Float32Array
-        const rotations = particlesRef.current.geometry.attributes.rotation.array as Float32Array
+      const positionAttribute = pointCloud.geometry.attributes.position
+      const sizeAttribute = pointCloud.geometry.attributes.size
+      const rotationAttribute = pointCloud.geometry.attributes.rotation
+      const particlePositions = positionAttribute.array as Float32Array
+      const particleSizes = sizeAttribute.array as Float32Array
+      const particleRotations = rotationAttribute.array as Float32Array
 
-        for (let i = 0; i < particleCount; i++) {
-          const i3 = i * 3
+      for (let i = 0; i < particleCount; i++) {
+        const i3 = i * 3
+        particlePositions[i3 + 1] += speeds[i] * 0.48
 
-          // Move particles upward with varying speeds
-          positions[i3 + 1] += speeds[i] * 0.5
-
-          // Reset particles that go out of bounds
-          if (positions[i3 + 1] > 10) {
-            positions[i3 + 1] = -10
-            positions[i3] = (Math.random() - 0.5) * (isMobile ? 20 : 30)
-            positions[i3 + 2] = (Math.random() - 0.5) * (isMobile ? 10 : 20)
-          }
-
-          // Rotate particles
-          rotations[i] += 0.01 * (i % 2 === 0 ? 1 : -1)
-
-          // Pulse size slightly - reduced effect on mobile
-          const pulseIntensity = isMobile ? 0.2 : 0.3
-          sizes[i] =
-            (Math.sin(time * 1.5 + i) * pulseIntensity + 1.2) *
-            (Math.random() * (isMobile ? 0.8 : 1.5) + (isMobile ? 0.3 : 0.5))
+        if (particlePositions[i3 + 1] > ySpread / 2) {
+          particlePositions[i3 + 1] = -ySpread / 2
+          particlePositions[i3] = (random() - 0.5) * xSpread
+          particlePositions[i3 + 2] = zNear - random() * zDepth
         }
 
-        particlesRef.current.geometry.attributes.position.needsUpdate = true
-        particlesRef.current.geometry.attributes.size.needsUpdate = true
-        particlesRef.current.geometry.attributes.rotation.needsUpdate = true
+        particleRotations[i] += 0.008 * (i % 2 === 0 ? 1 : -1)
+        particleSizes[i] = (Math.sin(time * 1.35 + i) * 0.18 + 1.15) * (baseSizes[i] * 0.9)
       }
 
-      if (gridRef.current) {
-        // Subtle grid movement - reduced on mobile
-        const movementIntensity = isMobile ? 0.3 : 0.5
-        gridRef.current.position.y = Math.sin(time * 0.2) * movementIntensity
-        gridRef.current.rotation.x = Math.PI / 8 + Math.sin(time * 0.1) * (isMobile ? 0.03 : 0.05)
-      }
+      positionAttribute.needsUpdate = true
+      sizeAttribute.needsUpdate = true
+      rotationAttribute.needsUpdate = true
+
+      grid.position.x = Math.sin(time * 0.12) * (isMobile ? 0.18 : 0.32)
+      grid.rotation.x = Math.PI / 5 + Math.sin(time * 0.08) * (isMobile ? 0.02 : 0.035)
 
       renderer.render(scene, camera)
     }
 
-    animate()
+    if (reducedMotionRef.current) {
+      renderStill()
+    } else {
+      animate()
+    }
 
-    // Cleanup
     return () => {
       window.removeEventListener("mousemove", handleMouseMove)
+      window.removeEventListener("scroll", applyScrollState)
       cancelAnimationFrame(frameRef.current)
 
       if (rendererRef.current) {
         container.removeChild(rendererRef.current.domElement)
+        rendererRef.current.dispose()
       }
 
-      if (particlesRef.current) {
-        particlesRef.current.geometry.dispose()
-        ;(particlesRef.current.material as THREE.Material).dispose()
-      }
-
-      if (gridRef.current) {
-        gridRef.current.geometry.dispose()
-        ;(gridRef.current.material as THREE.Material).dispose()
-      }
+      particles.dispose()
+      particleMaterial.dispose()
+      gridGeometry.dispose()
+      gridMaterial.dispose()
 
       sceneRef.current = null
       cameraRef.current = null
       rendererRef.current = null
       particlesRef.current = null
       gridRef.current = null
+      gridMaterialRef.current = null
+      particleMaterialRef.current = null
+      frameRef.current = 0
     }
-  }, [isMobile])
+  }, [isMobile, isMounted])
 
   useEffect(() => {
     if (!cameraRef.current || !rendererRef.current) return
 
     const width = Math.max(viewport.width, 1)
     const height = Math.max(viewport.height, 1)
+    const pixelRatio = Math.min(window.devicePixelRatio || 1, isMobile ? 1.15 : 1.5)
 
     cameraRef.current.aspect = width / height
     cameraRef.current.updateProjectionMatrix()
+    rendererRef.current.setPixelRatio(pixelRatio)
     rendererRef.current.setSize(width, height)
 
-    const material = particlesRef.current?.material as THREE.ShaderMaterial | undefined
-    if (material?.uniforms) {
-      material.uniforms.pixelRatio.value = window.devicePixelRatio
+    if (particleMaterialRef.current?.uniforms) {
+      particleMaterialRef.current.uniforms.pixelRatio.value = pixelRatio
     }
-  }, [viewport.height, viewport.width])
+  }, [isMobile, viewport.height, viewport.width])
 
-  return <div ref={containerRef} className="absolute inset-0 -z-10 overflow-hidden" aria-hidden="true" />
+  if (!isMounted) return null
+
+  return createPortal(
+    <div className="home-webgl-stage fixed inset-0 z-0 overflow-hidden pointer-events-none" aria-hidden="true">
+      <div
+        ref={containerRef}
+        className="home-webgl-background absolute inset-0 z-0 overflow-hidden"
+      />
+      <div className="home-webgl-vignette" />
+      <div className="home-corruption-overlay" />
+      <div className="home-scan-distortion" />
+    </div>,
+    document.body,
+  )
 }


### PR DESCRIPTION
## Summary
- Promote the Three.js hero treatment into a full-homepage, body-level background scene.
- Keep one shared renderer with capped DPR, lower mobile particle counts, scroll-dimmed intensity, deterministic particles, and reduced-motion handling.
- Add homepage readability overlays and keep the footer above the fixed background layer.

## Validation
- `pnpm build`
- `pnpm test:type`
- `pnpm exec next lint`
- Browser QA on `http://127.0.0.1:3000/` with desktop and 390x844 mobile viewport screenshots.
- Verified one full-viewport canvas, no framework overlay, no new console warnings/errors, fixed canvas while scrolling, and role-fit form navigation to `/projects?focus=immersive%20creative%20technologist`.

## Notes
- Draft PR so the visual direction can be reviewed before merge.