### PR TITLE
[codex] Gate Snow Crash effects behind Metaverse mode

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -58,10 +58,7 @@ export default function RootLayout({
           aria-hidden="true"
         ></div>
 
-        {/*
-         * SnowCrashEffects includes SumerianVirus and KatanaCursor.
-         * No fallback is needed as the nested MetaverseNav handles its own loading.
-         */}
+        {/* SnowCrashEffects keeps the opt-in Metaverse entry available on the homepage. */}
         <SnowCrashEffects />
 
         <main className="flex-1 container mx-auto px-4 pt-20 pb-8 relative z-10">

--- a/components/metaverse-nav.tsx
+++ b/components/metaverse-nav.tsx
@@ -19,6 +19,9 @@ const Canvas = dynamic(() => import("@react-three/fiber").then((m) => m.Canvas),
     </div>
   ),
 })
+const SumerianVirus = dynamic(() => import("./sumerian-virus").then((m) => m.SumerianVirus), { ssr: false })
+const KatanaCursor = dynamic(() => import("./katana-cursor").then((m) => m.KatanaCursor), { ssr: false })
+const SnowCrashTakeover = dynamic(() => import("./snow-crash-takeover").then((m) => m.SnowCrashTakeover), { ssr: false })
 
 // -----------------------------------------------------------------------------
 // Shared HUD style tokens (inject once)
@@ -1651,6 +1654,14 @@ const applyTransforms = useCallback(() => {
           }
         `}
         </style>
+
+        {showMetaverse && (
+          <Suspense fallback={null}>
+            <SnowCrashTakeover />
+            <SumerianVirus />
+            <KatanaCursor />
+          </Suspense>
+        )}
 
         {/* Status HUD (top-left) */}
         {showMetaverse && (

--- a/components/metaverse-nav.tsx
+++ b/components/metaverse-nav.tsx
@@ -1617,6 +1617,14 @@ const applyTransforms = useCallback(() => {
         )}
       </AnimatePresence>
 
+      {showMetaverse && (
+        <Suspense fallback={null}>
+          <SnowCrashTakeover />
+          <SumerianVirus />
+          <KatanaCursor />
+        </Suspense>
+      )}
+
       {/* Overlay navigation (The Street) */}
       <motion.nav
         aria-label="Metaverse navigation"
@@ -1654,14 +1662,6 @@ const applyTransforms = useCallback(() => {
           }
         `}
         </style>
-
-        {showMetaverse && (
-          <Suspense fallback={null}>
-            <SnowCrashTakeover />
-            <SumerianVirus />
-            <KatanaCursor />
-          </Suspense>
-        )}
 
         {/* Status HUD (top-left) */}
         {showMetaverse && (

--- a/components/snow-crash-effects.tsx
+++ b/components/snow-crash-effects.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import dynamic from 'next/dynamic'
-import { Suspense } from 'react'
 import { usePathname } from 'next/navigation'
 const MetaverseNav = dynamic(
   () => import('./metaverse-nav').then((m) => m.MetaverseNav),
@@ -16,26 +15,13 @@ const MetaverseNav = dynamic(
 )
 const SiteNav = dynamic(() => import('./site-nav').then((m) => m.SiteNav), { ssr: false })
 
-// Only non-essential effects are dynamically loaded to keep the initial
-// bundle small while ensuring the main navigation is present immediately.
-const SumerianVirus = dynamic(() => import('./sumerian-virus').then(m => m.SumerianVirus), { ssr: false })
-const KatanaCursor = dynamic(() => import('./katana-cursor').then(m => m.KatanaCursor), { ssr: false })
-const SnowCrashTakeover = dynamic(() => import('./snow-crash-takeover').then(m => m.SnowCrashTakeover), { ssr: false })
-
 export function SnowCrashEffects() {
   const pathname = usePathname()
-  const showAmbientEffects = pathname === "/"
+  const showMetaverseEntry = pathname === "/"
 
   return (
     <>
-      {showAmbientEffects ? <MetaverseNav /> : <SiteNav />}
-      {showAmbientEffects && (
-        <Suspense>
-          <SnowCrashTakeover />
-          <SumerianVirus />
-          <KatanaCursor />
-        </Suspense>
-      )}
+      {showMetaverseEntry ? <MetaverseNav /> : <SiteNav />}
     </>
   )
 }


### PR DESCRIPTION
## Summary
- Stop loading the random Sumerian virus, Snow Crash vignette, and katana cursor on the normal homepage.
- Mount those Snow Crash effects only while the opt-in Enter Metaverse overlay is active.
- Update the layout comment to reflect the calmer default portfolio behavior.

## Validation
- `pnpm build`
- `pnpm test:type`
- `pnpm exec next lint`
- Browser QA on `http://127.0.0.1:3000/`: default homepage has no Snow Crash takeover/vignette nodes and no custom cursor state; Enter Metaverse mounts the takeover/cursor; Exit Metaverse clears them again; no fresh console warnings/errors.

## Notes
- This keeps the creative Snow Crash treatment available only after explicit user intent, so hiring managers and clients do not see surprise virus-like behavior on the default portfolio.