### PR TITLE
[codex] Add AI project filter

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -13,8 +13,18 @@ const MOBILE_BREAKPOINT_PX = 767
 const PROJECTS_LIMIT_MOBILE = 3
 const PROJECTS_LIMIT_DESKTOP = 6
 
+const AI_PROJECT_IDS = [
+  "astrocade-qa-calibration-tool",
+  "wizzo",
+  "x-games",
+  "speakeasy",
+  "creative-supply-engine",
+  "vulnerability-visualizer",
+]
+
 const CATEGORIES = [
   { id: "all", name: "All Projects" },
+  { id: "ai", name: "AI" },
   { id: "design", name: "UX/UI Design" },
   { id: "ar-vr", name: "AR/VR" },
   { id: "web", name: "Web Development" },
@@ -73,10 +83,20 @@ export default function ProjectsPage() {
   }, [])
 
   const filteredProjects = useMemo(
-    () =>
-      activeFilter === "all"
-        ? PROJECTS
-        : PROJECTS.filter((project) => project.category === activeFilter),
+    () => {
+      if (activeFilter === "all") {
+        return PROJECTS
+      }
+
+      if (activeFilter === "ai") {
+        const projectById = new Map(PROJECTS.map((project) => [project.id, project]))
+        return AI_PROJECT_IDS
+          .map((id) => projectById.get(id))
+          .filter((project): project is Project => Boolean(project))
+      }
+
+      return PROJECTS.filter((project) => project.category === activeFilter)
+    },
     [activeFilter]
   )
 

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -22,6 +22,8 @@ const AI_PROJECT_IDS = [
   "vulnerability-visualizer",
 ]
 
+const PROJECTS_BY_ID = new Map(PROJECTS.map((project) => [project.id, project]))
+
 const CATEGORIES = [
   { id: "all", name: "All Projects" },
   { id: "ai", name: "AI" },
@@ -89,9 +91,8 @@ export default function ProjectsPage() {
       }
 
       if (activeFilter === "ai") {
-        const projectById = new Map(PROJECTS.map((project) => [project.id, project]))
         return AI_PROJECT_IDS
-          .map((id) => projectById.get(id))
+          .map((id) => PROJECTS_BY_ID.get(id))
           .filter((project): project is Project => Boolean(project))
       }
 


### PR DESCRIPTION
## Summary
- add a curated AI tab to the Projects page without changing project categories
- surface exactly Astrocade AI QA Calibration Tool, Wizzo, X Games, SpeakEasy, Creative Supply Engine, and Vulnerability Visualizer
- preserve the requested order and intentionally leave AI Energy Consumption out until it uses a live AI API

## Validation
- pnpm exec next lint
- pnpm test:type
- pnpm test:unit
- pnpm build
- git diff --check
- browser QA: AI tab shows six requested projects in order, excludes AI Energy Consumption, and has no console warnings/errors