### PR TITLE
Refine project detail media layout

### DIFF
--- a/app/projects/[id]/ProjectMediaShowcase.tsx
+++ b/app/projects/[id]/ProjectMediaShowcase.tsx
@@ -12,7 +12,7 @@ interface ProjectMediaShowcaseProps {
 }
 
 function getImageAlt(title: string, index: number) {
-  return index === 0 ? `${title} primary project image` : `${title} supporting artifact ${index}`
+  return index === 0 ? `${title} primary project image` : `${title} supporting artifact ${index + 1}`
 }
 
 function getThumbnailLabel(title: string, index: number) {

--- a/app/projects/[id]/ProjectMediaShowcase.tsx
+++ b/app/projects/[id]/ProjectMediaShowcase.tsx
@@ -1,0 +1,93 @@
+"use client"
+
+import Image from "next/image"
+import { Maximize2 } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+interface ProjectMediaShowcaseProps {
+  title: string
+  images: string[]
+  onOpen: (index: number) => void
+  className?: string
+}
+
+function getImageAlt(title: string, index: number) {
+  return index === 0 ? `${title} primary project image` : `${title} supporting artifact ${index}`
+}
+
+function getThumbnailLabel(title: string, index: number) {
+  return `Open ${title} artifact thumbnail ${index + 1} fullscreen`
+}
+
+export function ProjectMediaShowcase({ title, images, onOpen, className }: ProjectMediaShowcaseProps) {
+  if (images.length === 0) return null
+
+  const primaryImage = images[0]
+
+  return (
+    <section className={cn("terminal-window overflow-hidden", className)} aria-label={`${title} project media`}>
+      <div className="terminal-header">
+        <div className="terminal-button terminal-button-red"></div>
+        <div className="terminal-button terminal-button-yellow"></div>
+        <div className="terminal-button terminal-button-green"></div>
+        <div className="terminal-title">artifact_viewer.sh</div>
+        <div className="ml-auto hidden text-xs uppercase text-primary/70 sm:block">
+          {images.length} artifact{images.length === 1 ? "" : "s"}
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_14rem]">
+        <button
+          type="button"
+          onClick={() => onOpen(0)}
+          className="group relative flex min-h-[18rem] items-center justify-center overflow-hidden rounded-md border border-primary/25 bg-black/70 p-3 text-left transition-colors hover:border-primary/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary md:min-h-[26rem]"
+          aria-label={`Open ${getImageAlt(title, 0)} fullscreen`}
+        >
+          <div className="bg-grid-pattern pointer-events-none absolute inset-0 opacity-25" />
+          <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(0,255,140,0.10),transparent_24%,rgba(0,0,0,0.40))]" />
+          <Image
+            src={primaryImage}
+            alt={getImageAlt(title, 0)}
+            width={1600}
+            height={1000}
+            className="relative z-10 max-h-[min(68vh,620px)] w-full rounded-sm object-contain"
+            sizes="(min-width: 1280px) 760px, (min-width: 1024px) 60vw, 100vw"
+            priority
+          />
+          <span className="absolute right-3 top-3 z-20 inline-flex items-center gap-2 rounded border border-primary/30 bg-black/70 px-2 py-1 text-xs text-primary opacity-90 backdrop-blur-sm transition-opacity group-hover:opacity-100">
+            <Maximize2 className="h-3.5 w-3.5" aria-hidden="true" />
+            Fullscreen
+          </span>
+        </button>
+
+        {images.length > 1 && (
+          <div
+            className="grid grid-cols-3 gap-3 lg:max-h-[min(68vh,620px)] lg:grid-cols-1 lg:auto-rows-[5.5rem] lg:overflow-y-auto lg:pr-1"
+            aria-label={`${title} supporting media`}
+          >
+            {images.map((image, index) => (
+              <button
+                key={`${image}-${index}`}
+                type="button"
+                onClick={() => onOpen(index)}
+                className="group relative h-20 w-full overflow-hidden rounded border border-zinc-800 bg-black/80 p-1 transition-colors hover:border-primary/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary lg:h-auto"
+                aria-label={getThumbnailLabel(title, index)}
+              >
+                <Image
+                  src={image}
+                  alt={getImageAlt(title, index)}
+                  fill
+                  className="object-contain"
+                  sizes="(min-width: 1024px) 224px, 128px"
+                />
+                <span className="absolute left-1.5 top-1.5 rounded bg-black/70 px-1.5 py-0.5 text-[10px] font-mono text-primary/80">
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/app/projects/[id]/ProjectPageClient.tsx
+++ b/app/projects/[id]/ProjectPageClient.tsx
@@ -1,10 +1,10 @@
 "use client"
 
-import Image from "next/image"
 import Link from "next/link"
 import { ArrowLeft, Github, ExternalLink } from "lucide-react"
-import { useState, useCallback, useEffect } from "react"
+import { useState, useCallback, useEffect, useMemo } from "react"
 import { ImageModal } from "@/components/image-modal"
+import { ProjectMediaShowcase } from "./ProjectMediaShowcase"
 
 interface DetailItem {
   title: string
@@ -44,7 +44,13 @@ interface ProjectPageClientProps {
 export default function ProjectPageClient({ project }: ProjectPageClientProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
 
-  const images = project ? [project.image, ...(project.gallery || [])] : []
+  const images = useMemo(
+    () =>
+      Array.from(
+        new Set([project.image, ...(project.gallery || [])].filter((image): image is string => Boolean(image)))
+      ),
+    [project.gallery, project.image]
+  )
 
   const closeModal = useCallback(() => setSelectedIndex(null), [])
 
@@ -117,68 +123,39 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
         </div>
       </div>
 
-      <div
-        className="relative h-80 rounded-md overflow-hidden cursor-pointer"
-        onClick={() => setSelectedIndex(0)}
-      >
-        <Image
-          src={
-            project.image ||
-            `/api/placeholder?width=1200&height=600&text=${encodeURIComponent(project.title)}`
-          }
-          alt={project.title}
-          fill
-          className="object-cover"
-          sizes="(min-width: 1024px) 960px, 100vw"
-          priority
-        />
-      </div>
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-start">
+        <div className="space-y-5 lg:order-2">
+          <div className="prose prose-invert max-w-none">
+            <h2 className="text-2xl font-bold mb-4">Project Overview</h2>
+            <p className="text-muted-foreground">{project.description || "No description available."}</p>
+          </div>
 
-      {project.gallery && (
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          {project.gallery.map((img: string, index: number) => (
-            <div
-              key={index}
-              className="relative bg-zinc-100 rounded-md overflow-hidden h-[200px] cursor-pointer"
-              onClick={() => setSelectedIndex(index + 1)}
+          <div className="flex flex-wrap gap-4">
+            <a
+              href={project.github}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 bg-secondary hover:bg-secondary/80 text-secondary-foreground px-4 py-2 rounded-md transition-colors"
             >
-              <Image
-                src={
-                  img ||
-                  `/api/placeholder?width=800&height=600&text=${encodeURIComponent(project.title)}`
-                }
-                alt={`${project.title} gallery image ${index + 1}`}
-                fill
-                className="object-cover"
-                sizes="(min-width: 1024px) 320px, (min-width: 768px) 33vw, 100vw"
-              />
-            </div>
-          ))}
+              <Github size={16} /> View on GitHub
+            </a>
+            <a
+              href={project.demo}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 bg-primary/10 hover:bg-primary/20 text-primary px-4 py-2 rounded-md transition-colors border border-primary/30"
+            >
+              <ExternalLink size={16} /> Live Demo
+            </a>
+          </div>
         </div>
-      )}
 
-      <div className="flex flex-wrap gap-4">
-        <a
-          href={project.github}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 bg-secondary hover:bg-secondary/80 text-secondary-foreground px-4 py-2 rounded-md transition-colors"
-        >
-          <Github size={16} /> View on GitHub
-        </a>
-        <a
-          href={project.demo}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 bg-primary/10 hover:bg-primary/20 text-primary px-4 py-2 rounded-md transition-colors border border-primary/30"
-        >
-          <ExternalLink size={16} /> Live Demo
-        </a>
-      </div>
-
-      <div className="prose prose-invert max-w-none">
-        <h2 className="text-2xl font-bold mb-4">Project Overview</h2>
-        <p className="text-muted-foreground">{project.description || "No description available."}</p>
+        <ProjectMediaShowcase
+          title={project.title}
+          images={images}
+          onOpen={setSelectedIndex}
+          className="lg:order-1"
+        />
       </div>
 
       {project.details && project.details.situation && typeof project.details.situation === "string" && (


### PR DESCRIPTION
## Summary
- replace the cropped top-of-page gallery stack with a terminal-style media showcase that preserves image aspect ratios
- move Project Overview and project CTAs into the first detail section so case study context is visible before the media stack on mobile and beside it on desktop
- keep the existing fullscreen image modal/carousel behavior, with accessible button controls for primary and thumbnail media

## Validation
- pnpm exec next lint
- pnpm test:type
- pnpm test:unit
- pnpm build
- git diff --check
- Browser QA at http://127.0.0.1:3001/projects/creative-supply-engine and /projects/x-games
  - desktop and mobile layouts render without framework overlays or console warnings
  - primary image and thumbnail controls open the existing fullscreen modal
  - single-image project omits the supporting thumbnail rail