### PR TITLE
[codex] Clarify portfolio narrative thread

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -467,8 +467,13 @@ export default function AboutPage() {
               </ol>
               <div className="flex flex-wrap gap-3 border-t border-primary/20 pt-4">
                 <Button asChild size="sm">
-                  <Link href="/projects?focus=human-in-the-loop%20AI%20systems">
-                    Open AI Proof <ArrowRight size={14} />
+                  <Link
+                    href={{
+                      pathname: "/projects",
+                      query: { focus: "human-in-the-loop AI systems" },
+                    }}
+                  >
+                    View AI Proofs <ArrowRight size={14} />
                   </Link>
                 </Button>
                 <Button asChild size="sm" variant="outline">

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState, type FormEvent, type ReactNode, useTransition } from "react"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faXTwitter } from "@fortawesome/free-brands-svg-icons"
-import { Activity, Cpu, Download, Github, Linkedin, Mail, Network, RefreshCw, type LucideIcon } from "lucide-react"
+import { Activity, ArrowRight, Cpu, Download, Github, Linkedin, Mail, Network, RefreshCw, type LucideIcon } from "lucide-react"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -65,6 +65,24 @@ const selectedProofPoints = [
   {
     id: "enterprise-systems",
     text: "Built enterprise internal tools, spatial operations prototypes, and WebGL systems for Starbucks, Ford, and POWER Engineers.",
+  },
+]
+
+const narrativeThreadItems = [
+  {
+    id: "thesis",
+    label: "01 / Thesis",
+    text: "The homepage frames the core position: AI-native product systems for messy workflows where automation and judgment meet.",
+  },
+  {
+    id: "operating-model",
+    label: "02 / Operating Model",
+    text: "This page explains the working model: define workflows, design interfaces, build prototypes, calibrate loops, and ship usable systems.",
+  },
+  {
+    id: "proof",
+    label: "03 / Proof",
+    text: "Project pages show the artifacts behind that model across AI QA, creator tools, automation, accessibility, and immersive systems.",
   },
 ]
 
@@ -419,6 +437,46 @@ export default function AboutPage() {
                   {paragraph.text}
                 </p>
               ))}
+            </TerminalWindow>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold mb-6">From Positioning To Proof</h2>
+            <TerminalWindow title="narrative_thread.sh" contentClassName="space-y-5">
+              <div className="space-y-2">
+                <p>
+                  <span className="text-primary">$</span> trace portfolio_throughline
+                </p>
+                <p className="text-muted-foreground">
+                  The throughline is simple: I turn ambiguous human/AI workflows
+                  into product systems people can operate, evaluate, and improve.
+                </p>
+              </div>
+              <ol className="grid gap-3 md:grid-cols-3">
+                {narrativeThreadItems.map((item) => (
+                  <li
+                    key={item.id}
+                    className="rounded border border-primary/20 bg-background/50 p-4"
+                  >
+                    <p className="mb-2 font-mono text-xs uppercase text-primary">
+                      {item.label}
+                    </p>
+                    <p className="text-sm text-muted-foreground">{item.text}</p>
+                  </li>
+                ))}
+              </ol>
+              <div className="flex flex-wrap gap-3 border-t border-primary/20 pt-4">
+                <Button asChild size="sm">
+                  <Link href="/projects?focus=human-in-the-loop%20AI%20systems">
+                    Open AI Proof <ArrowRight size={14} />
+                  </Link>
+                </Button>
+                <Button asChild size="sm" variant="outline">
+                  <Link href="/projects/astrocade-qa-calibration-tool">
+                    Start With Astrocade <ArrowRight size={14} />
+                  </Link>
+                </Button>
+              </div>
             </TerminalWindow>
           </section>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,8 +33,9 @@ const HOME_HERO_LINES = [
   "AI-native design engineer for product systems,",
   "human-in-the-loop AI, and operational UX.",
   "",
-  "$ route --next",
-  "View work, systems, or full profile.",
+  "$ trace --portfolio",
+  "Start with the thesis, inspect the operating model,",
+  "then open the proof in project case studies.",
 ]
 
 function HomeHeroTerminal({ onComplete }: { onComplete: () => void }) {
@@ -188,6 +189,18 @@ export default function Home() {
           <p><span className="text-primary">$</span> Internal tools and operational UX</p>
           <p><span className="text-primary">$</span> Product + design + engineering alignment</p>
           <p><span className="text-primary">$</span> Creator workflows, moderation, and QA calibration</p>
+          <div className="mt-4 flex flex-wrap gap-3 border-t border-primary/20 pt-4">
+            <Button asChild size="sm">
+              <Link href="/about">
+                Read Positioning <ArrowRight size={14} />
+              </Link>
+            </Button>
+            <Button asChild size="sm" variant="outline">
+              <Link href="/projects">
+                Inspect Proof <ArrowRight size={14} />
+              </Link>
+            </Button>
+          </div>
         </div>
       </section>
 

--- a/app/projects/[id]/ProjectPageClient.tsx
+++ b/app/projects/[id]/ProjectPageClient.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { ArrowLeft, Github, ExternalLink } from "lucide-react"
+import { ArrowLeft, ArrowRight, Github, ExternalLink } from "lucide-react"
 import { useState, useCallback, useEffect, useMemo } from "react"
 import type { ReactNode } from "react"
 import { ImageModal } from "@/components/image-modal"
@@ -214,6 +214,10 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
                 </span>
               ))}
             </p>
+            <p>
+              <span className="text-primary">proof role:</span> concrete
+              evidence for the operating model
+            </p>
           </div>
         </div>
       </div>
@@ -223,6 +227,12 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
           <div className="case-study-overview space-y-3">
             <h2 className="case-study-section-title">Project Overview</h2>
             <p className="case-study-detail-body">{project.description || "No description available."}</p>
+            <Link
+              href="/about"
+              className="inline-flex items-center gap-1 text-sm text-primary transition-colors hover:text-primary/80"
+            >
+              Revisit operating model <ArrowRight size={14} />
+            </Link>
           </div>
 
           {projectLinks.length > 0 && (

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -145,9 +145,17 @@ export default function ProjectsPage() {
         </div>
         <div className="terminal-content">
           <p className="mb-2">
-            <span className="text-primary">$</span> Displaying projects directory. Select category to filter results.
+            <span className="text-primary">$</span> open proof_layer
           </p>
-          <p className="text-xs text-muted-foreground">Adaptive Focus is now available for natural-language personalization.</p>
+          <p className="text-sm text-muted-foreground">
+            These projects are the evidence layer for the same thesis:
+            AI-native product systems, human-in-the-loop workflows, and
+            operational tools that make complex work usable.
+          </p>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Use filters or Adaptive Focus to match proof to a role, client need,
+            or collaboration.
+          </p>
         </div>
       </div>
 

--- a/docs/backlog/FUTURE_BACKLOG.md
+++ b/docs/backlog/FUTURE_BACKLOG.md
@@ -40,7 +40,6 @@ If another doc, review, critique, or conversation records a follow-up, it must a
 
 ## Content And Case Study Depth
 
-- [ ] Add a clearer narrative thread from homepage to About to project pages.
 - [ ] Add outcome metrics where safe and credible, especially for Astrocade and operational UX work.
 - [ ] Add a short "how I work" page only if it does not duplicate About or resume content.
 - [ ] Add more explicit accessibility process evidence for SpeakEasy and Transcribe.


### PR DESCRIPTION
## Summary
- Adds homepage copy and CTAs that point visitors from the core thesis into positioning and project proof.
- Adds an About-page bridge section that ties the homepage thesis, About operating model, and project case studies together.
- Updates the projects index and project-detail template so case studies read as the proof layer for the operating model.
- Removes the completed narrative-thread item from the future backlog.

## Validation
- pnpm exec next lint
- pnpm test:type
- pnpm check:links
- pnpm test
- pnpm build
- Browser QA at http://localhost:3001 for homepage -> About -> projects -> project detail narrative flow
