### PR TITLE
Turn Astrocade into an evidence dossier

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -434,6 +434,281 @@ textarea {
   line-height: 1.75;
 }
 
+.evidence-dossier {
+  width: min(100%, 1520px);
+  margin-inline: auto;
+  padding-inline: clamp(0.9rem, 2.4vw, 2rem);
+}
+
+.evidence-dossier-hero {
+  position: relative;
+  overflow: hidden;
+  border-block: 1px solid rgba(255, 255, 255, 0.14);
+  background:
+    linear-gradient(90deg, rgba(0, 255, 140, 0.04), transparent 38%),
+    rgba(0, 0, 0, 0.72);
+}
+
+.evidence-dossier-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(to bottom, rgba(255, 255, 255, 0.018) 0 1px, transparent 1px 5px);
+  opacity: 0.5;
+}
+
+.evidence-dossier-status,
+.evidence-dossier-hero-grid,
+.evidence-dossier-capabilities {
+  position: relative;
+  z-index: 1;
+}
+
+.evidence-dossier-status {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem 1.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 0.55rem 0.85rem;
+  color: rgb(113 113 122);
+  font-size: 0.58rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.evidence-dossier-status span:nth-child(2) {
+  color: #00ff8c;
+}
+
+.evidence-dossier-hero-grid {
+  display: grid;
+  gap: 2rem;
+  padding: clamp(1.5rem, 4vw, 4rem) clamp(1rem, 2.7vw, 2.75rem);
+}
+
+.evidence-dossier-eyebrow,
+.dossier-section-kicker {
+  color: #00ff8c;
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.evidence-dossier-title {
+  max-width: 18ch;
+  margin-top: 0.55rem;
+  color: #ffffff;
+  font-family: var(--font-display), sans-serif;
+  font-size: clamp(3.25rem, 7vw, 7.5rem);
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 0.84;
+  text-transform: uppercase;
+}
+
+.evidence-dossier-summary {
+  max-width: 62rem;
+  margin-top: 1.25rem;
+  color: rgb(212 212 216);
+  font-size: clamp(0.95rem, 1.4vw, 1.15rem);
+  line-height: 1.7;
+}
+
+.evidence-dossier-ledger {
+  display: grid;
+  align-content: start;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.evidence-dossier-ledger > div {
+  display: grid;
+  grid-template-columns: minmax(7.5rem, 0.7fr) 1.3fr;
+  gap: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 0.8rem 0;
+}
+
+.evidence-dossier-ledger dt,
+.evidence-dossier-index dt {
+  color: rgb(113 113 122);
+  font-size: 0.62rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.evidence-dossier-ledger dd {
+  color: rgb(228 228 231);
+  font-size: 0.78rem;
+  line-height: 1.55;
+}
+
+.evidence-dossier-capabilities {
+  display: flex;
+  flex-wrap: wrap;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 0.7rem 1rem;
+}
+
+.evidence-dossier-capabilities span {
+  border-right: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 0.25rem 0.75rem;
+  color: rgb(161 161 170);
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.evidence-dossier-artifact .terminal-window,
+.evidence-dossier .terminal-window {
+  border-color: rgba(255, 255, 255, 0.15);
+  border-radius: 2px;
+  box-shadow: inset 0 0 34px rgba(0, 255, 140, 0.025);
+}
+
+.evidence-dossier-body {
+  display: grid;
+  gap: clamp(2rem, 5vw, 5rem);
+}
+
+.evidence-dossier-index {
+  align-self: start;
+  border-left: 1px solid rgba(0, 255, 140, 0.45);
+  padding-left: 1rem;
+}
+
+.evidence-dossier-index nav > p {
+  margin-bottom: 0.65rem;
+  color: rgb(113 113 122);
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.evidence-dossier-index nav a {
+  display: grid;
+  grid-template-columns: 2rem 1fr;
+  align-items: center;
+  min-height: 2.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  color: rgb(212 212 216);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: color 160ms ease, border-color 160ms ease;
+}
+
+.evidence-dossier-index nav a:hover,
+.evidence-dossier-index nav a:focus-visible {
+  border-color: rgba(0, 255, 140, 0.55);
+  color: #00ff8c;
+}
+
+.evidence-dossier-index nav a span {
+  color: rgb(82 82 91);
+}
+
+.evidence-dossier-index > dl {
+  display: grid;
+  gap: 0.8rem;
+  margin-top: 1.5rem;
+}
+
+.evidence-dossier-index dd {
+  margin-top: 0.2rem;
+  color: rgb(161 161 170);
+  font-size: 0.68rem;
+  line-height: 1.5;
+}
+
+.evidence-dossier-sections {
+  min-width: 0;
+}
+
+.evidence-dossier-sections .case-study-section {
+  padding-block: 0.25rem clamp(3rem, 7vw, 6rem);
+}
+
+.evidence-dossier-sections .case-study-section-title {
+  margin-top: 0.35rem;
+  font-family: var(--font-display), sans-serif;
+  font-size: clamp(2.5rem, 5vw, 4.5rem);
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 0.95;
+  text-transform: uppercase;
+}
+
+.evidence-dossier-sections .case-study-detail-grid {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 17rem), 1fr));
+  gap: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.13);
+}
+
+.evidence-dossier-sections .case-study-detail-card {
+  border: 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: 0;
+  background: transparent;
+  padding: 1.2rem 1.1rem 1.35rem 0;
+}
+
+.evidence-dossier-sections .case-study-detail-card + .case-study-detail-card {
+  padding-left: 1.1rem;
+}
+
+.evidence-dossier-sections .case-study-detail-title {
+  font-size: 0.86rem;
+}
+
+.evidence-dossier-sections #outcomes .case-study-detail-card {
+  border-top: 2px solid rgba(0, 255, 140, 0.55);
+}
+
+@media (min-width: 1024px) {
+  .evidence-dossier-hero-grid {
+    grid-template-columns: minmax(0, 1.6fr) minmax(18rem, 0.7fr);
+    align-items: end;
+  }
+
+  .evidence-dossier-body {
+    grid-template-columns: 13rem minmax(0, 1fr);
+  }
+
+  .evidence-dossier-index {
+    position: sticky;
+    top: 6rem;
+  }
+}
+
+@media (max-width: 767px) {
+  .evidence-dossier-status span:last-child {
+    display: none;
+  }
+
+  .evidence-dossier-title {
+    font-size: clamp(3rem, 16vw, 5.5rem);
+  }
+
+  .evidence-dossier-ledger > div {
+    grid-template-columns: 1fr;
+    gap: 0.25rem;
+  }
+
+  .evidence-dossier-capabilities span {
+    width: 100%;
+    border-right: 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .evidence-dossier-sections .case-study-detail-card + .case-study-detail-card {
+    padding-left: 0;
+  }
+}
+
 @media (min-width: 640px) {
   .case-study-detail-card {
     padding: 1.125rem 1.25rem;

--- a/app/projects/[id]/ProjectPageClient.tsx
+++ b/app/projects/[id]/ProjectPageClient.tsx
@@ -323,7 +323,7 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
           </aside>
         )}
 
-        <div className={isEvidenceDossier ? "evidence-dossier-sections" : "contents"}>
+        <div className={isEvidenceDossier ? "evidence-dossier-sections" : "space-y-8"}>
 
       {project.details && project.details.situation && typeof project.details.situation === "string" && (
         <CaseStudySection id="situation" kicker={isEvidenceDossier ? "01 / Context" : undefined} title="Situation" evidence={renderEvidence("situation", "Situation")}>

--- a/app/projects/[id]/ProjectPageClient.tsx
+++ b/app/projects/[id]/ProjectPageClient.tsx
@@ -56,14 +56,19 @@ interface ProjectPageClientProps {
 function CaseStudySection({
   children,
   evidence,
+  id,
+  kicker,
   title,
 }: {
   children: ReactNode
   evidence?: ReactNode
+  id?: string
+  kicker?: string
   title: string
 }) {
   return (
-    <section className="case-study-section space-y-4">
+    <section id={id} className="case-study-section space-y-4">
+      {kicker && <p className="dossier-section-kicker">{kicker}</p>}
       <h2 className="case-study-section-title">{title}</h2>
       {children}
       {evidence}
@@ -93,6 +98,7 @@ function DetailItemCard({ item, marker }: { item: DetailItem; marker: string }) 
 
 export default function ProjectPageClient({ project }: ProjectPageClientProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
+  const isEvidenceDossier = project.id === "astrocade-qa-calibration-tool"
   const projectLinks = useMemo(
     () => [
       ...(project.github
@@ -176,99 +182,157 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
     ) : null
   }
 
+  const projectLinkActions = projectLinks.length > 0 && (
+    <div className="flex flex-wrap gap-3">
+      {projectLinks.map((link) => (
+        <a
+          key={`${link.label}-${link.href}`}
+          href={link.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`inline-flex min-h-10 items-center gap-2 border px-4 py-2 text-xs font-semibold uppercase tracking-[0.1em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+            isEvidenceDossier
+              ? "border-primary/40 bg-primary/10 text-primary hover:bg-primary/20"
+              : link.style
+          }`}
+        >
+          {link.type === "github" ? <Github size={16} /> : <ExternalLink size={16} />}
+          {link.label}
+        </a>
+      ))}
+    </div>
+  )
+
   return (
-    <div className="space-y-8 pt-8">
-      <h1 className="sr-only">{project.title || "Project Details"}</h1>
-      <Link href="/projects" className="inline-flex items-center gap-2 text-primary hover:underline">
-        <ArrowLeft size={16} /> Back to projects
+    <div className={isEvidenceDossier ? "evidence-dossier space-y-10 pt-6" : "space-y-8 pt-8"}>
+      {!isEvidenceDossier && <h1 className="sr-only">{project.title || "Project Details"}</h1>}
+      <Link href="/projects" className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.12em] text-primary transition-colors hover:text-white">
+        <ArrowLeft size={16} /> Back to systems
       </Link>
 
-      <div className="terminal-window case-study-terminal">
-        <div className="terminal-header">
-          <div className="terminal-button terminal-button-red"></div>
-          <div className="terminal-button terminal-button-yellow"></div>
-          <div className="terminal-button terminal-button-green"></div>
-          <div className="terminal-title">project_details.sh</div>
-        </div>
-        <div className="terminal-content case-study-meta">
-          <p className="case-study-command">
-            <span className="text-primary">$</span> cat {project.id}.json
-          </p>
-          <div className="case-study-meta-grid">
-            <p>
-              <span className="text-primary">title:</span> {project.title}
-            </p>
-            <p>
-              <span className="text-primary">category:</span> {project.category}
-            </p>
-            <p>
-              <span className="text-primary">client:</span> {project.details.client}
-            </p>
-            <p>
-              <span className="text-primary">date:</span> {project.details.date}
-            </p>
-            <p className="case-study-stack-row">
-              <span className="text-primary">stack:</span>
-              {project.technologies.map((tech: string, index: number) => (
-                <span key={index} className="text-xs px-2 py-1 bg-secondary text-secondary-foreground rounded">
-                  {tech}
-                </span>
-              ))}
-            </p>
-            <p>
-              <span className="text-primary">proof role:</span>{" "}
-              {project.details.proofRole || "concrete evidence for the operating model"}
-            </p>
-          </div>
-        </div>
-      </div>
-
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-start">
-        <div className="space-y-5 lg:order-2">
-          <div className="case-study-overview space-y-3">
-            <h2 className="case-study-section-title">Project Overview</h2>
-            <p className="case-study-detail-body">{project.description || "No description available."}</p>
-            <Link
-              href="/about"
-              className="inline-flex items-center gap-1 text-sm text-primary transition-colors hover:text-primary/80"
-            >
-              Revisit operating model <ArrowRight size={14} />
-            </Link>
-          </div>
-
-          {projectLinks.length > 0 && (
-            <div className="flex flex-wrap gap-4">
-              {projectLinks.map((link) => (
-                <a
-                  key={`${link.label}-${link.href}`}
-                  href={link.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={`inline-flex items-center gap-2 px-4 py-2 rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${link.style}`}
-                >
-                  {link.type === "github" ? <Github size={16} /> : <ExternalLink size={16} />}
-                  {link.label}
-                </a>
-              ))}
+      {isEvidenceDossier ? (
+        <>
+          <section className="evidence-dossier-hero" aria-labelledby="dossier-title">
+            <div className="evidence-dossier-status">
+              <span>CASE FILE / AF-01</span>
+              <span>REVIEWED EVIDENCE</span>
+              <span>ACTIVE SYSTEM / {project.details.date}</span>
             </div>
-          )}
-        </div>
 
-        <ProjectMediaShowcase
-          media={media}
-          onOpen={setSelectedIndex}
-          className="lg:order-1"
-        />
-      </div>
+            <div className="evidence-dossier-hero-grid">
+              <div>
+                <p className="evidence-dossier-eyebrow">AI SYSTEMS ENGINEERING / HUMAN CONTROL LAYER</p>
+                <h1 id="dossier-title" className="evidence-dossier-title">{project.title}</h1>
+                <p className="evidence-dossier-summary">{project.description}</p>
+                <div className="mt-6">{projectLinkActions}</div>
+              </div>
+
+              <dl className="evidence-dossier-ledger">
+                <div>
+                  <dt>Operating proof</dt>
+                  <dd>{project.details.proofRole}</dd>
+                </div>
+                <div>
+                  <dt>Engagement</dt>
+                  <dd>{project.details.client}</dd>
+                </div>
+                <div>
+                  <dt>Evidence set</dt>
+                  <dd>{media.length} reviewed artifacts</dd>
+                </div>
+                <div>
+                  <dt>Capability coverage</dt>
+                  <dd>{project.details.services?.length || 0} documented areas</dd>
+                </div>
+              </dl>
+            </div>
+
+            <div className="evidence-dossier-capabilities" aria-label="Documented capabilities">
+              {project.details.services?.map((service) => <span key={service}>{service}</span>)}
+            </div>
+          </section>
+
+          <section className="evidence-dossier-artifact" aria-labelledby="primary-artifact-title">
+            <div className="signal-section-heading">
+              <h2 id="primary-artifact-title">Primary artifact</h2>
+              <span>01 / {String(media.length).padStart(2, "0")}</span>
+            </div>
+            <ProjectMediaShowcase media={media} onOpen={setSelectedIndex} />
+          </section>
+        </>
+      ) : (
+        <>
+          <div className="terminal-window case-study-terminal">
+            <div className="terminal-header">
+              <div className="terminal-button terminal-button-red"></div>
+              <div className="terminal-button terminal-button-yellow"></div>
+              <div className="terminal-button terminal-button-green"></div>
+              <div className="terminal-title">project_details.sh</div>
+            </div>
+            <div className="terminal-content case-study-meta">
+              <p className="case-study-command">
+                <span className="text-primary">$</span> cat {project.id}.json
+              </p>
+              <div className="case-study-meta-grid">
+                <p><span className="text-primary">title:</span> {project.title}</p>
+                <p><span className="text-primary">category:</span> {project.category}</p>
+                <p><span className="text-primary">client:</span> {project.details.client}</p>
+                <p><span className="text-primary">date:</span> {project.details.date}</p>
+                <p className="case-study-stack-row">
+                  <span className="text-primary">stack:</span>
+                  {project.technologies.map((tech: string, index: number) => (
+                    <span key={index} className="rounded bg-secondary px-2 py-1 text-xs text-secondary-foreground">{tech}</span>
+                  ))}
+                </p>
+                <p><span className="text-primary">proof role:</span> {project.details.proofRole || "concrete evidence for the operating model"}</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-start">
+            <div className="space-y-5 lg:order-2">
+              <div className="case-study-overview space-y-3">
+                <h2 className="case-study-section-title">Project Overview</h2>
+                <p className="case-study-detail-body">{project.description || "No description available."}</p>
+                <Link href="/about" className="inline-flex items-center gap-1 text-sm text-primary transition-colors hover:text-primary/80">
+                  Revisit operating model <ArrowRight size={14} />
+                </Link>
+              </div>
+              {projectLinkActions}
+            </div>
+            <ProjectMediaShowcase media={media} onOpen={setSelectedIndex} className="lg:order-1" />
+          </div>
+        </>
+      )}
+
+      <div className={isEvidenceDossier ? "evidence-dossier-body" : ""}>
+        {isEvidenceDossier && (
+          <aside className="evidence-dossier-index">
+            <nav aria-label="Case study sections">
+              <p>Case index</p>
+              <a href="#situation"><span>01</span> Situation</a>
+              <a href="#mandate"><span>02</span> Mandate</a>
+              <a href="#build"><span>03</span> Build</a>
+              <a href="#outcomes"><span>04</span> Outcomes</a>
+            </nav>
+            <dl>
+              <div><dt>Artifacts</dt><dd>{String(media.length).padStart(2, "0")}</dd></div>
+              <div><dt>Signals</dt><dd>Ground truth / QA / Feedback</dd></div>
+              <div><dt>Integrity</dt><dd>Repository reviewed</dd></div>
+            </dl>
+          </aside>
+        )}
+
+        <div className={isEvidenceDossier ? "evidence-dossier-sections" : "contents"}>
 
       {project.details && project.details.situation && typeof project.details.situation === "string" && (
-        <CaseStudySection title="Situation" evidence={renderEvidence("situation", "Situation")}>
+        <CaseStudySection id="situation" kicker={isEvidenceDossier ? "01 / Context" : undefined} title="Situation" evidence={renderEvidence("situation", "Situation")}>
           <DetailTextCard text={project.details.situation} />
         </CaseStudySection>
       )}
 
       {project.details && project.details.situation && Array.isArray(project.details.situation) && (
-        <CaseStudySection title="Situation" evidence={renderEvidence("situation", "Situation")}>
+        <CaseStudySection id="situation" kicker={isEvidenceDossier ? "01 / Context" : undefined} title="Situation" evidence={renderEvidence("situation", "Situation")}>
           <div className="case-study-detail-grid">
             {project.details.situation.map((item: DetailItem, index: number) => (
               <DetailItemCard key={index} item={item} marker="•" />
@@ -278,13 +342,13 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
       )}
 
       {project.details && project.details.task && typeof project.details.task === "string" && (
-        <CaseStudySection title="Task" evidence={renderEvidence("task", "Task")}>
+        <CaseStudySection id="mandate" kicker={isEvidenceDossier ? "02 / Mandate" : undefined} title={isEvidenceDossier ? "Mandate" : "Task"} evidence={renderEvidence("task", "Task")}>
           <DetailTextCard text={project.details.task} />
         </CaseStudySection>
       )}
 
       {project.details && project.details.task && Array.isArray(project.details.task) && (
-        <CaseStudySection title="Task" evidence={renderEvidence("task", "Task")}>
+        <CaseStudySection id="mandate" kicker={isEvidenceDossier ? "02 / Mandate" : undefined} title={isEvidenceDossier ? "Mandate" : "Task"} evidence={renderEvidence("task", "Task")}>
           <div className="case-study-detail-grid">
             {project.details.task.map((item: DetailItem, index: number) => (
               <DetailItemCard key={index} item={item} marker="•" />
@@ -294,7 +358,7 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
       )}
 
       {project.details && project.details.actions && (
-        <CaseStudySection title="Action" evidence={renderEvidence("action", "Action")}>
+        <CaseStudySection id="build" kicker={isEvidenceDossier ? "03 / Build" : undefined} title={isEvidenceDossier ? "Build" : "Action"} evidence={renderEvidence("action", "Action")}>
           <div className="case-study-detail-grid">
             {project.details.actions.map((action: DetailItem, index: number) => (
               <DetailItemCard key={index} item={action} marker={`${index + 1}.`} />
@@ -304,7 +368,7 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
       )}
 
       {project.details && project.details.results && (
-        <CaseStudySection title="Result" evidence={renderEvidence("result", "Result")}>
+        <CaseStudySection id="outcomes" kicker={isEvidenceDossier ? "04 / Outcomes" : undefined} title={isEvidenceDossier ? "Outcomes" : "Result"} evidence={renderEvidence("result", "Result")}>
           <div className="case-study-detail-grid">
             {project.details.results.map((result: DetailItem, index: number) => (
               <DetailItemCard key={index} item={result} marker="•" />
@@ -314,7 +378,7 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
       )}
 
       {project.details && project.details.result && (
-        <CaseStudySection title="Result" evidence={renderEvidence("result", "Result")}>
+        <CaseStudySection id="outcomes" kicker={isEvidenceDossier ? "04 / Outcomes" : undefined} title={isEvidenceDossier ? "Outcomes" : "Result"} evidence={renderEvidence("result", "Result")}>
           <DetailTextCard text={project.details.result} />
         </CaseStudySection>
       )}
@@ -328,6 +392,8 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
           </div>
         </CaseStudySection>
       )}
+        </div>
+      </div>
       <ImageModal
         open={selectedIndex !== null}
         onOpenChange={(o) => !o && closeModal()}

--- a/design-qa-astrocade.md
+++ b/design-qa-astrocade.md
@@ -1,0 +1,40 @@
+# Astrocade Evidence Dossier Design QA
+
+## Reference
+
+- Production baseline: `/tmp/astrocade-production-viewport-before.png`
+- Evidence dossier implementation: `/tmp/astrocade-dossier-viewport-v1.png`
+- Side-by-side comparison: `/tmp/astrocade-dossier-comparison-v1.png`
+- Mobile implementation: `/tmp/astrocade-dossier-mobile-v1.png`
+- Desktop viewport: 1265 x 712
+- Mobile viewport: 390 x 844
+
+## Product Intent
+
+The production page presented verified project content as a sequence of similarly weighted terminal containers. The dossier treatment preserves the terminal identity while establishing a clearer hiring-manager path: project identity, reviewed proof, primary artifact, case index, operating mandate, implementation evidence, and outcomes.
+
+## Visual Review
+
+- The project name is now the first case-study signal and uses the shared condensed display face introduced on the homepage.
+- The hero ledger uses repository-backed facts only: role, engagement, artifact count, and capability count.
+- The real calibration interface remains the dominant visual artifact.
+- The page retains the cyan/green signal palette, square framing, restrained scan lines, and dense terminal typography from the selected post-terminal direction.
+- Situation, Mandate, Build, and Outcomes provide stronger hierarchy without turning every section into another decorative card.
+- The long project title wraps cleanly on mobile without overlapping the summary, ledger, or primary action.
+
+## Interaction And Accessibility
+
+- The dossier uses one semantic H1 and ordered H2 sections.
+- The case index is a semantic navigation landmark with anchored section links.
+- Existing media buttons, fullscreen modal behavior, keyboard navigation, captions, and focus rings are preserved.
+- Desktop and mobile page loads produced no console errors.
+- Other project IDs continue to use the existing case-study template.
+
+## Validation
+
+- `pnpm test`: 73 tests passed
+- `pnpm lint`: passed
+- `pnpm check:links`: passed
+- `pnpm build`: passed
+
+final result: passed


### PR DESCRIPTION
## Summary
- establish the first reusable evidence-dossier treatment on the Astrocade case study
- lead with project identity, reviewed proof, and the real calibration artifact instead of metadata syntax
- add anchored Situation, Mandate, Build, and Outcomes navigation with repository-backed proof counts
- preserve the existing template for every other project while this pattern is evaluated

## Validation
- pnpm test (73 tests)
- pnpm lint
- pnpm check:links
- pnpm build
- desktop and mobile visual QA
- primary artifact modal and case-index navigation verified with no console errors

## Design QA
See design-qa-astrocade.md for the production baseline, side-by-side comparison, mobile capture, and acceptance notes.