### PR TITLE
Extend evidence dossiers to Wizzo

### DIFF
--- a/__tests__/wizzo-case-study.test.ts
+++ b/__tests__/wizzo-case-study.test.ts
@@ -1,0 +1,53 @@
+import fs from "node:fs"
+import path from "node:path"
+import { getEvidenceDossierConfig } from "../app/projects/[id]/dossierConfig"
+import { buildProjectMedia } from "../app/projects/[id]/projectMedia"
+
+interface WizzoProject {
+  gallery?: string[]
+  image: string
+  title: string
+  details: {
+    proofRole?: string
+    services?: string[]
+  }
+}
+
+const projects = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "..", "public", "data", "projects.json"), "utf8"),
+) as Record<string, WizzoProject>
+
+describe("Wizzo evidence dossier", () => {
+  it("uses explicit AI product-system proof instead of fallback copy", () => {
+    const project = projects.wizzo
+    expect(project).toBeDefined()
+    expect(project.details.proofRole).toContain("AI product systems")
+    expect(project.details.proofRole).toContain("accountable follow-through")
+    expect(project.details.services).toContain("Privacy Controls")
+  })
+
+  it("is enabled through typed dossier configuration", () => {
+    expect(getEvidenceDossierConfig("wizzo")).toEqual({
+      caseFile: "AF-02",
+      eyebrow: "AI product systems / Intent to action",
+      signals: "Chat / Context / Quests",
+    })
+    expect(getEvidenceDossierConfig("speak-easy")).toBeUndefined()
+  })
+
+  it("uses reviewed labels and captions for real product screens", () => {
+    const project = projects.wizzo
+    const media = buildProjectMedia({
+      gallery: project.gallery,
+      id: "wizzo",
+      image: project.image,
+      title: project.title,
+    })
+
+    expect(media.map((item) => item.label)).toEqual([
+      "AI mentor product cockpit",
+      "Quest progress system",
+    ])
+    expect(media.some((item) => item.section === "result")).toBe(true)
+  })
+})

--- a/app/projects/[id]/ProjectPageClient.tsx
+++ b/app/projects/[id]/ProjectPageClient.tsx
@@ -8,6 +8,7 @@ import { ImageModal } from "@/components/image-modal"
 import type { Project as ProjectSummary } from "@/types/project"
 import { ProjectEvidenceStrip } from "./ProjectEvidenceStrip"
 import { ProjectMediaShowcase } from "./ProjectMediaShowcase"
+import { getEvidenceDossierConfig } from "./dossierConfig"
 import { buildProjectMedia, getSectionMedia, type ProjectEvidenceSection } from "./projectMedia"
 
 interface DetailItem {
@@ -98,7 +99,8 @@ function DetailItemCard({ item, marker }: { item: DetailItem; marker: string }) 
 
 export default function ProjectPageClient({ project }: ProjectPageClientProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
-  const isEvidenceDossier = project.id === "astrocade-qa-calibration-tool"
+  const dossierConfig = getEvidenceDossierConfig(project.id)
+  const isEvidenceDossier = Boolean(dossierConfig)
   const projectLinks = useMemo(
     () => [
       ...(project.github
@@ -214,14 +216,14 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
         <>
           <section className="evidence-dossier-hero" aria-labelledby="dossier-title">
             <div className="evidence-dossier-status">
-              <span>CASE FILE / AF-01</span>
+              <span>CASE FILE / {dossierConfig?.caseFile}</span>
               <span>REVIEWED EVIDENCE</span>
               <span>ACTIVE SYSTEM / {project.details.date}</span>
             </div>
 
             <div className="evidence-dossier-hero-grid">
               <div>
-                <p className="evidence-dossier-eyebrow">AI SYSTEMS ENGINEERING / HUMAN CONTROL LAYER</p>
+                <p className="evidence-dossier-eyebrow">{dossierConfig?.eyebrow}</p>
                 <h1 id="dossier-title" className="evidence-dossier-title">{project.title}</h1>
                 <p className="evidence-dossier-summary">{project.description}</p>
                 <div className="mt-6">{projectLinkActions}</div>
@@ -317,7 +319,7 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
             </nav>
             <dl>
               <div><dt>Artifacts</dt><dd>{String(media.length).padStart(2, "0")}</dd></div>
-              <div><dt>Signals</dt><dd>Ground truth / QA / Feedback</dd></div>
+              <div><dt>Signals</dt><dd>{dossierConfig?.signals}</dd></div>
               <div><dt>Integrity</dt><dd>Repository reviewed</dd></div>
             </dl>
           </aside>

--- a/app/projects/[id]/dossierConfig.ts
+++ b/app/projects/[id]/dossierConfig.ts
@@ -1,0 +1,22 @@
+export interface EvidenceDossierConfig {
+  caseFile: string
+  eyebrow: string
+  signals: string
+}
+
+const EVIDENCE_DOSSIERS: Partial<Record<string, EvidenceDossierConfig>> = {
+  "astrocade-qa-calibration-tool": {
+    caseFile: "AF-01",
+    eyebrow: "AI systems engineering / Human control layer",
+    signals: "Ground truth / QA / Feedback",
+  },
+  wizzo: {
+    caseFile: "AF-02",
+    eyebrow: "AI product systems / Intent to action",
+    signals: "Chat / Context / Quests",
+  },
+}
+
+export function getEvidenceDossierConfig(projectId: string): EvidenceDossierConfig | undefined {
+  return EVIDENCE_DOSSIERS[projectId]
+}

--- a/design-qa-wizzo.md
+++ b/design-qa-wizzo.md
@@ -1,0 +1,40 @@
+# Wizzo Evidence Dossier Design QA
+
+## Reference
+
+- Production baseline: `/tmp/wizzo-production-before.png`
+- Evidence dossier implementation: `/tmp/wizzo-dossier-v1.png`
+- Side-by-side comparison: `/tmp/wizzo-dossier-comparison-v1.png`
+- Mobile implementation: `/tmp/wizzo-dossier-mobile-v1.png`
+- Desktop viewport: 1265 x 712
+- Mobile viewport: 390 x 844
+
+## Product Intent
+
+This slice validates the Astrocade evidence-dossier pattern against a second project with a different proof model. Wizzo needs to foreground shipped AI product architecture, connected work context, full-stack implementation, privacy controls, and intent-to-action workflows rather than human-in-the-loop calibration.
+
+## Implementation Review
+
+- A typed dossier configuration now owns case-file identity, positioning copy, and project-specific proof signals.
+- Astrocade and Wizzo use the same dossier structure without project-title conditionals in the presentation layer.
+- Wizzo now has an explicit public `proofRole` instead of falling back to generic operating-model copy.
+- Existing reviewed Wizzo media captions remain the canonical artifact source.
+- Marketing Site and Launch App remain distinct, visible actions.
+- Projects outside the dossier configuration continue to use the legacy case-study template and spacing.
+
+## Visual Review
+
+- The short Wizzo name receives strong first-viewport emphasis without artificial supporting decoration.
+- The proof ledger balances the compact title and keeps claims inspectable.
+- Capability labels remain factual and derive from the public project record.
+- The primary real product screenshot remains visible immediately below the dossier header.
+- Mobile stacking keeps actions, proof, engagement, artifact count, and capabilities readable without overlap.
+
+## Validation
+
+- Wizzo and Astrocade render as evidence dossiers.
+- A non-configured project remains on the legacy template.
+- Desktop and mobile Wizzo loads produced no console errors.
+- `pnpm test`: 76 tests passed.
+
+final result: passed

--- a/public/data/projects.json
+++ b/public/data/projects.json
@@ -127,6 +127,7 @@
       "client": "Wizzo Labs",
       "date": "2025 - Present",
       "category": "AI Product Systems",
+      "proofRole": "AI product systems connecting intent, work context, and accountable follow-through",
       "services": [
         "AI Workflow Design",
         "Product Systems",


### PR DESCRIPTION
## Summary
- enable the evidence-dossier treatment for Wizzo as the second proof archetype
- replace the Astrocade-only condition with typed dossier configuration
- add Wizzo’s explicit AI product-system proof role to public project data
- preserve the reviewed Wizzo media catalog and the legacy template for non-configured projects

## Validation
- pnpm test (76 tests)
- pnpm lint
- pnpm check:links
- pnpm build
- desktop production comparison and 390px mobile QA
- Wizzo and Astrocade dossier contracts verified; non-configured project fallback tested

## Design QA
See design-qa-wizzo.md for baseline, comparison, mobile capture, and acceptance notes.