### PR TITLE
Iterate projects archive into a signal index

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1035,6 +1035,316 @@ textarea {
   box-shadow: inset 0 0 28px rgba(0, 255, 140, 0.025);
 }
 
+/* Projects archive signal index */
+.projects-index-page {
+  width: min(100%, 1520px);
+  margin-inline: auto;
+  padding-inline: clamp(0.9rem, 2.4vw, 2rem);
+}
+
+.project-index-hero {
+  position: relative;
+  overflow: hidden;
+  border-block: 1px solid rgba(255, 255, 255, 0.14);
+  background:
+    linear-gradient(90deg, rgba(0, 255, 140, 0.055), transparent 44%),
+    rgba(0, 0, 0, 0.78);
+}
+
+.project-index-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(to bottom, rgba(255, 255, 255, 0.018) 0 1px, transparent 1px 5px);
+  opacity: 0.5;
+}
+
+.project-index-status,
+.project-index-hero-grid {
+  position: relative;
+  z-index: 1;
+}
+
+.project-index-status {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem 1.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 0.55rem 0.85rem;
+  color: rgb(113 113 122);
+  font-size: 0.58rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.project-index-status span:nth-child(2) {
+  color: #00ff8c;
+}
+
+.project-index-hero-grid {
+  display: grid;
+  gap: 2rem;
+  padding: clamp(1.5rem, 4vw, 3.75rem) clamp(1rem, 2.7vw, 2.75rem);
+}
+
+.project-index-eyebrow {
+  color: #00ff8c;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.project-index-title {
+  max-width: 14ch;
+  margin-top: 0.55rem;
+  color: #ffffff;
+  font-family: var(--font-display), sans-serif;
+  font-size: clamp(3rem, 6.2vw, 6.5rem);
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 0.85;
+  text-transform: uppercase;
+}
+
+.project-index-summary {
+  max-width: 46rem;
+  margin-top: 1.1rem;
+  color: rgb(212 212 216);
+  font-size: clamp(0.9rem, 1.25vw, 1.05rem);
+  line-height: 1.7;
+}
+
+.project-index-ledger {
+  display: grid;
+  align-content: start;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.project-index-ledger > div {
+  display: grid;
+  grid-template-columns: minmax(7.5rem, 1fr) auto;
+  gap: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 0.78rem 0;
+}
+
+.project-index-ledger dt {
+  color: rgb(113 113 122);
+  font-size: 0.62rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.project-index-ledger dd {
+  color: rgb(228 228 231);
+  font-size: 0.78rem;
+  line-height: 1.55;
+  text-align: right;
+}
+
+.archive-focus-deck {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(0, 0, 0, 0.82);
+}
+
+.archive-focus-heading,
+.project-archive-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 0.85rem 1rem;
+}
+
+.archive-focus-heading h2,
+.project-archive-heading h2 {
+  margin-top: 0.25rem;
+  color: #ffffff;
+  font-size: clamp(1.1rem, 2vw, 1.45rem);
+  font-weight: 700;
+}
+
+.archive-focus-heading > p,
+.project-archive-heading > p {
+  max-width: 34rem;
+  color: rgb(113 113 122);
+  font-size: 0.7rem;
+  line-height: 1.55;
+  text-align: right;
+}
+
+.archive-focus-presets {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.archive-focus-preset {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.65rem;
+  min-height: 3.7rem;
+  border-right: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 0.7rem 0.8rem;
+  color: rgb(212 212 216);
+  text-align: left;
+  transition: background-color 160ms ease, color 160ms ease;
+}
+
+.archive-focus-preset:last-child {
+  border-right: 0;
+}
+
+.archive-focus-preset > span {
+  color: rgb(82 82 91);
+  font-size: 0.58rem;
+  letter-spacing: 0.08em;
+}
+
+.archive-focus-preset strong {
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.archive-focus-preset svg {
+  color: #00ff8c;
+  transition: transform 160ms ease;
+}
+
+.archive-focus-preset:hover {
+  background: rgba(0, 255, 140, 0.06);
+  color: #ffffff;
+}
+
+.archive-focus-preset:hover svg {
+  transform: translateX(2px);
+}
+
+.archive-focus-preset:focus-visible,
+.project-category-control:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: 2px solid #00ff8c;
+  outline-offset: -2px;
+}
+
+.archive-focus-preset:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.archive-focus-form {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+}
+
+.project-archive-section {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.project-category-index {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.project-category-control {
+  display: flex;
+  min-height: 2.9rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border-right: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 0.65rem 0.75rem;
+  color: rgb(161 161 170);
+  font-size: 0.68rem;
+  text-align: left;
+  transition: background-color 160ms ease, color 160ms ease;
+}
+
+.project-category-control:last-child {
+  border-right: 0;
+}
+
+.project-category-control strong {
+  color: rgb(82 82 91);
+  font-size: 0.58rem;
+  font-weight: 600;
+}
+
+.project-category-control:hover {
+  background: rgba(255, 255, 255, 0.035);
+  color: #ffffff;
+}
+
+.project-category-control-active {
+  background: #00ff8c;
+  color: #000000;
+}
+
+.project-category-control-active strong {
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.project-archive-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.project-archive-record {
+  display: grid;
+  min-width: 0;
+  grid-template-rows: auto 1fr;
+}
+
+.project-archive-record-meta {
+  display: flex;
+  min-height: 1.9rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-bottom: 0;
+  padding: 0.38rem 0.55rem;
+  color: rgb(82 82 91);
+  font-size: 0.55rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.project-archive-dossier-mark {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #00ff8c;
+}
+
+.project-archive-record .signal-project-card {
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.project-archive-record:has(.project-archive-dossier-mark) .signal-project-card {
+  border-color: rgba(0, 255, 140, 0.28);
+}
+
+@media (min-width: 900px) {
+  .project-index-hero-grid {
+    grid-template-columns: minmax(0, 1.45fr) minmax(17rem, 0.55fr);
+    align-items: center;
+  }
+}
+
 .terminal-window,
 .card-hover {
   border-radius: 2px;
@@ -1065,6 +1375,34 @@ footer .container {
 @media (max-width: 1023px) {
   .post-terminal-hero-scene {
     background-position: 58% center;
+  }
+
+  .archive-focus-presets {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .archive-focus-preset:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .archive-focus-preset:nth-child(-n + 4) {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  }
+
+  .project-category-index {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .project-category-control:nth-child(3n) {
+    border-right: 0;
+  }
+
+  .project-category-control:nth-child(-n + 3) {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  }
+
+  .project-archive-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
@@ -1100,6 +1438,44 @@ footer .container {
   .signal-section-heading h2 {
     max-width: 15rem;
     line-height: 1.5;
+  }
+
+  .project-index-status span:last-child {
+    display: none;
+  }
+
+  .project-index-title {
+    font-size: clamp(2.75rem, 15vw, 4.5rem);
+  }
+
+  .archive-focus-heading,
+  .project-archive-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .archive-focus-heading > p,
+  .project-archive-heading > p {
+    text-align: left;
+  }
+
+  .archive-focus-presets,
+  .project-category-index,
+  .project-archive-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .archive-focus-preset,
+  .archive-focus-preset:nth-child(2n),
+  .project-category-control,
+  .project-category-control:nth-child(3n) {
+    border-right: 0;
+  }
+
+  .archive-focus-preset:not(:last-child),
+  .project-category-control:not(:last-child) {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
   }
 }
 

--- a/app/projects/[id]/dossierConfig.ts
+++ b/app/projects/[id]/dossierConfig.ts
@@ -17,6 +17,10 @@ const EVIDENCE_DOSSIERS: Partial<Record<string, EvidenceDossierConfig>> = {
   },
 }
 
+export const EVIDENCE_DOSSIER_PROJECT_IDS = Object.freeze(
+  new Set(Object.keys(EVIDENCE_DOSSIERS))
+)
+
 export function getEvidenceDossierConfig(projectId: string): EvidenceDossierConfig | undefined {
   return EVIDENCE_DOSSIERS[projectId]
 }

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useCallback, useEffect, useId, useMemo, useRef, useState, type FormEvent } from "react"
-import { LoaderCircle } from "lucide-react"
+import { ArrowRight, FileCheck2, LoaderCircle } from "lucide-react"
 import { NeonSeparator } from "@/components/neon-separator"
 import { ProjectCard } from "@/components/project-card"
 import { RoleFitBrief } from "@/components/role-fit-brief"
@@ -25,6 +25,7 @@ import {
 } from "@/features/adaptive-focus/handoff"
 import { useAdaptiveFocusHandoff } from "@/features/adaptive-focus/handoff-context"
 import type { Project } from "@/types/project"
+import { EVIDENCE_DOSSIER_PROJECT_IDS } from "./[id]/dossierConfig"
 
 const MOBILE_BREAKPOINT_PX = 767
 const PROJECTS_LIMIT_MOBILE = 3
@@ -79,6 +80,13 @@ export default function ProjectsPage() {
     () => CATEGORIES.find((category) => category.id === activeFilter)?.name ?? "Projects",
     [activeFilter]
   )
+
+  const categoryCounts = useMemo(
+    () => new Map(CATEGORIES.map((category) => [category.id, projectsForCategory(category.id).length])),
+    []
+  )
+
+  const visibleProjects = display.slice(0, showAll ? display.length : initialLimit)
 
   const applyBrief = useCallback((result: AdaptiveFocusV2Result) => {
     setBrief(result)
@@ -225,55 +233,72 @@ export default function ProjectsPage() {
   }
 
   return (
-    <div className="space-y-8 pt-8">
-      <h1 className="sr-only">Projects</h1>
+    <div className="projects-index-page space-y-6 pt-6">
       <p className="sr-only" aria-live="polite" aria-atomic="true">
         {statusMessage}
       </p>
 
-      <div className="terminal-window">
-        <div className="terminal-header">
-          <div className="terminal-button terminal-button-red"></div>
-          <div className="terminal-button terminal-button-yellow"></div>
-          <div className="terminal-button terminal-button-green"></div>
-          <div className="terminal-title">projects.sh</div>
-        </div>
-        <div className="terminal-content">
-          <p className="mb-2">
-            <span className="text-primary">$</span> open proof_layer
-          </p>
-          <p className="text-sm text-muted-foreground">
-            These projects are the evidence layer for AI-native product systems, human-in-the-loop workflows, and operational tools that make complex work usable.
-          </p>
-          <p className="mt-2 text-xs text-muted-foreground">
-            Use a preset lens or analyze custom role text to build an evidence-grounded Role Fit Brief.
-          </p>
-        </div>
-      </div>
-
-      <NeonSeparator intensity="medium" />
-
-      <section className="space-y-5" aria-labelledby="adaptive-focus-controls-heading">
-        <div>
-          <p className="text-xs font-semibold uppercase text-primary">Adaptive Focus</p>
-          <h2 id="adaptive-focus-controls-heading" className="mt-1 text-xl font-bold">Build a Role Fit Brief</h2>
+      <section className="project-index-hero" aria-labelledby="project-index-title">
+        <div className="project-index-status" aria-hidden="true">
+          <span>ARCHIVE / {PROJECTS.length.toString().padStart(2, "0")} RECORDS</span>
+          <span>PROOF / REVIEWED</span>
+          <span>INDEX / ONLINE</span>
         </div>
 
-        <div className="flex flex-wrap gap-2" aria-label="Preset role lenses">
-          {ADAPTIVE_FOCUS_PRESETS.map((preset) => (
+        <div className="project-index-hero-grid">
+          <div>
+            <p className="project-index-eyebrow">Portfolio evidence layer</p>
+            <h1 id="project-index-title" className="project-index-title">
+              Project Signal Index
+            </h1>
+            <p className="project-index-summary">
+              These projects are the evidence layer for AI-native product systems, human-in-the-loop workflows, and operational tools that make complex work usable.
+            </p>
+          </div>
+
+          <dl className="project-index-ledger">
+            <div>
+              <dt>Projects indexed</dt>
+              <dd>{PROJECTS.length.toString().padStart(2, "0")}</dd>
+            </div>
+            <div>
+              <dt>Evidence dossiers</dt>
+              <dd>{EVIDENCE_DOSSIER_PROJECT_IDS.size.toString().padStart(2, "0")}</dd>
+            </div>
+            <div>
+              <dt>Active view</dt>
+              <dd>{brief ? "Role fit" : activeCategoryName}</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+
+      <section className="archive-focus-deck" aria-labelledby="adaptive-focus-controls-heading">
+        <div className="archive-focus-heading">
+          <div>
+            <p className="project-index-eyebrow">Adaptive Focus / Role lens</p>
+            <h2 id="adaptive-focus-controls-heading">Build a Role Fit Brief</h2>
+          </div>
+          <p>Map a target role to reviewed evidence, then inspect the strongest proof first.</p>
+        </div>
+
+        <div className="archive-focus-presets" aria-label="Preset role lenses">
+          {ADAPTIVE_FOCUS_PRESETS.map((preset, index) => (
             <button
               key={preset.id}
               type="button"
               onClick={() => void executeRequest({ mode: "preset", presetId: preset.id })}
               disabled={requestState === "loading"}
-              className="rounded-md border border-primary/25 px-3 py-2 text-left text-sm transition-colors hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-wait disabled:opacity-60"
+              className="archive-focus-preset"
             >
-              {preset.label}
+              <span aria-hidden="true">{(index + 1).toString().padStart(2, "0")}</span>
+              <strong>{preset.label}</strong>
+              <ArrowRight size={14} aria-hidden="true" />
             </button>
           ))}
         </div>
 
-        <form className="space-y-3" onSubmit={handleSubmit}>
+        <form className="archive-focus-form" onSubmit={handleSubmit}>
           <div className="flex flex-wrap items-baseline justify-between gap-2">
             <label htmlFor={inputId} className="text-sm font-medium">Role, responsibilities, or job description</label>
             <span className="text-xs text-muted-foreground">
@@ -287,7 +312,7 @@ export default function ProjectsPage() {
             maxLength={ADAPTIVE_FOCUS_INPUT_MAX_LENGTH}
             onChange={(event) => setQuery(event.target.value)}
             placeholder="Senior design engineer building AI-assisted creative workflows and internal tools..."
-            className="min-h-28 resize-y bg-black/20"
+            className="min-h-24 resize-y rounded-none border-white/15 bg-black/45 focus-visible:ring-primary"
           />
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <p className="max-w-3xl text-xs leading-5 text-muted-foreground">
@@ -323,41 +348,61 @@ export default function ProjectsPage() {
 
       <NeonSeparator intensity="low" />
 
-      <section className="space-y-5" aria-labelledby="project-archive-heading">
-        <div className="flex flex-wrap gap-2" aria-label="Project categories">
+      <section className="project-archive-section" aria-labelledby="project-archive-heading">
+        <div className="project-archive-heading">
+          <div>
+            <p className="project-index-eyebrow">Indexed records</p>
+            <h2 id="project-archive-heading">
+              {brief ? "Project archive in relevance order" : activeCategoryName}
+            </h2>
+          </div>
+          <p aria-live="polite">
+            Showing {visibleProjects.length.toString().padStart(2, "0")} of {display.length.toString().padStart(2, "0")}
+          </p>
+        </div>
+
+        <div className="project-category-index" aria-label="Project categories">
           {CATEGORIES.map((category) => (
             <button
               key={category.id}
               type="button"
               onClick={() => handleCategoryChange(category.id)}
               aria-pressed={!brief && activeFilter === category.id}
-              className={`rounded-md px-3 py-1 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+              className={`project-category-control ${
                 !brief && activeFilter === category.id
-                  ? "bg-primary text-primary-foreground"
-                  : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
+                  ? "project-category-control-active"
+                  : ""
               }`}
             >
-              {category.name}
+              <span>{category.name}</span>
+              <strong>{(categoryCounts.get(category.id) ?? 0).toString().padStart(2, "0")}</strong>
             </button>
           ))}
         </div>
 
-        <h2 id="project-archive-heading" className="text-xl font-bold">
-          {brief ? "Project archive in relevance order" : activeCategoryName}
-        </h2>
-
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-          {display.slice(0, showAll ? display.length : initialLimit).map((project, index) => (
-            <ProjectCard
-              key={project.id}
-              id={project.id}
-              title={project.title}
-              description={project.description}
-              image={project.image}
-              technologies={project.technologies}
-              category={project.category}
-              priority={index === 0}
-            />
+        <div className="project-archive-grid">
+          {visibleProjects.map((project, index) => (
+            <div key={project.id} className="project-archive-record">
+              <div className="project-archive-record-meta">
+                <span>REC / {(index + 1).toString().padStart(2, "0")}</span>
+                {EVIDENCE_DOSSIER_PROJECT_IDS.has(project.id) ? (
+                  <span className="project-archive-dossier-mark">
+                    <FileCheck2 size={12} aria-hidden="true" /> Evidence dossier
+                  </span>
+                ) : (
+                  <span>Case study</span>
+                )}
+              </div>
+              <ProjectCard
+                id={project.id}
+                title={project.title}
+                description={project.description}
+                image={project.image}
+                technologies={project.technologies}
+                category={project.category}
+                priority={index === 0}
+              />
+            </div>
           ))}
         </div>
         {!showAll && display.length > initialLimit ? (

--- a/design-qa-projects-archive.md
+++ b/design-qa-projects-archive.md
@@ -1,0 +1,40 @@
+# Projects Archive Signal Index Design QA
+
+## Reference
+
+- Production baseline: `/tmp/projects-archive-production-before.png`
+- Signal index implementation: `/tmp/projects-archive-local-desktop.png`
+- Side-by-side comparison: `/tmp/projects-archive-comparison.png`
+- Desktop viewport: 1280 x 720
+
+## Product Intent
+
+The production archive opened as a terminal introduction followed by a large role-analysis form. The signal-index iteration preserves the existing Adaptive Focus workflow and project ordering while turning the archive into a clearer evidence navigation surface: archive status, reviewed dossier volume, role lenses, category counts, and indexed project records.
+
+## Visual Review
+
+- The visible H1 now establishes the archive as a Project Signal Index and matches the homepage and evidence-dossier display hierarchy.
+- The header ledger uses repository-derived values for project and dossier counts.
+- Adaptive Focus is presented as a compact command deck with indexed preset lenses, without changing engine behavior.
+- Category controls show repository-derived result counts and preserve pressed-state semantics.
+- Project entries retain real project media and the existing card component while adding record numbers and evidence-dossier markers.
+- The first two reviewed dossiers are visually distinct without changing canonical project order.
+- Responsive rules collapse the header, lenses, categories, and project grid to single-column layouts below the existing mobile breakpoint.
+
+## Interaction And Accessibility
+
+- The page has one visible semantic H1 and ordered H2 sections.
+- Category buttons retain `aria-pressed`, keyboard focus rings, and deterministic filtering.
+- The AI category showed six records and the Human-in-the-loop AI preset produced a Role Fit Brief with the archive in relevance order.
+- Adaptive Focus request status remains in the existing polite live region.
+- Browser interaction checks produced no console errors.
+- Reduced-motion handling remains inherited from the shared signal-card system.
+
+## Validation
+
+- `pnpm test`: 76 tests passed
+- `pnpm lint`: passed
+- `pnpm check:links`: passed
+- `pnpm build`: passed
+
+final result: passed


### PR DESCRIPTION
## Summary
- replace the generic projects terminal intro with a data-backed Project Signal Index
- consolidate Adaptive Focus presets into an indexed command deck and add category result counts
- label project records and automatically surface reviewed evidence dossiers from the shared dossier config
- document production-to-local visual QA

## Behavior
- preserves existing Adaptive Focus ranking, handoff, fallback, reset, and category filtering
- preserves canonical project order and the existing project card component

## Validation
- `pnpm test` (76 tests)
- `pnpm lint`
- `pnpm check:links`
- `pnpm build`
- local browser checks for AI filtering, preset Role Fit Brief generation, focus/pressed states, and console errors