### PR TITLE
Turn Transcribe into an evidence dossier

### DIFF
--- a/__tests__/project-media.test.ts
+++ b/__tests__/project-media.test.ts
@@ -24,6 +24,15 @@ const HIGH_SIGNAL_PROJECT_IDS = [
 ]
 
 describe("high-signal project media", () => {
+  test("the shared viewer eagerly loads compact supporting thumbnails", () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, "..", "app", "projects", "[id]", "ProjectMediaShowcase.tsx"),
+      "utf8",
+    )
+
+    expect(source).toContain('loading="eager"')
+  })
+
   test.each(HIGH_SIGNAL_PROJECT_IDS)("%s has explicit media copy", (id) => {
     const project = projects[id]
     expect(project).toBeDefined()

--- a/__tests__/transcribe-case-study.test.ts
+++ b/__tests__/transcribe-case-study.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs"
+import path from "node:path"
+import { getEvidenceDossierConfig } from "../app/projects/[id]/dossierConfig"
+import { buildProjectMedia } from "../app/projects/[id]/projectMedia"
+
+interface DetailItem {
+  description: string
+  title: string
+}
+
+interface TranscribeProject {
+  gallery?: string[]
+  image: string
+  title: string
+  details: {
+    proofRole?: string
+    result?: string
+    results?: DetailItem[]
+    services?: string[]
+  }
+}
+
+const projects = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "..", "public", "data", "projects.json"), "utf8"),
+) as Record<string, TranscribeProject>
+
+describe("Transcribe evidence dossier", () => {
+  it("states the accessibility implementation role and attributes measured outcomes", () => {
+    const project = projects.transcribe
+    expect(project).toBeDefined()
+    expect(project.details.proofRole).toContain("accessible voice interaction")
+    expect(project.details.services).toEqual([
+      "Accessibility UX",
+      "Voice Interaction",
+      "React Development",
+      "Field Validation",
+    ])
+    expect(project.details.result).toBeUndefined()
+
+    const resultCopy = project.details.results
+      ?.map(({ description, title }) => `${title} ${description}`)
+      .join(" ")
+    expect(resultCopy).toContain("30% Transcription-Accuracy Improvement")
+    expect(resultCopy).toContain("50% Less Manual Note-Taking Time")
+    expect(resultCopy).toContain("case-study record reports")
+  })
+
+  it("is enabled through the shared dossier configuration", () => {
+    expect(getEvidenceDossierConfig("transcribe")).toEqual({
+      caseFile: "AF-06",
+      eyebrow: "Voice accessibility systems / Retail operations",
+      signals: "Listen / Transcribe / Test / Operate",
+    })
+  })
+
+  it("maps the reviewed pilot evidence to the dossier sections", () => {
+    const project = projects.transcribe
+    const media = buildProjectMedia({
+      gallery: project.gallery,
+      id: "transcribe",
+      image: project.image,
+      title: project.title,
+    })
+
+    expect(media).toHaveLength(5)
+    expect(media.map((item) => item.label)).toEqual([
+      "Drive-through transcription system",
+      "Communication roadmap and pilot plan",
+      "Interface and implementation record",
+      "Listening-state and in-store testing",
+      "Documented pilot outcomes",
+    ])
+    expect(media.filter((item) => item.section === "situation")).toHaveLength(1)
+    expect(media.filter((item) => item.section === "action")).toHaveLength(2)
+    expect(media.filter((item) => item.section === "result")).toHaveLength(1)
+  })
+})

--- a/app/projects/[id]/ProjectMediaShowcase.tsx
+++ b/app/projects/[id]/ProjectMediaShowcase.tsx
@@ -81,6 +81,7 @@ export function ProjectMediaShowcase({ media, onOpen, className }: ProjectMediaS
                   src={item.src}
                   alt={item.alt}
                   fill
+                  loading="eager"
                   className="object-contain"
                   sizes="(min-width: 1024px) 224px, 128px"
                 />

--- a/app/projects/[id]/dossierConfig.ts
+++ b/app/projects/[id]/dossierConfig.ts
@@ -30,6 +30,11 @@ const EVIDENCE_DOSSIERS: Partial<Record<string, EvidenceDossierConfig>> = {
     eyebrow: "Manufacturing workflow systems / Measured operations",
     signals: "Observe / Capture / Analyze / Scale",
   },
+  transcribe: {
+    caseFile: "AF-06",
+    eyebrow: "Voice accessibility systems / Retail operations",
+    signals: "Listen / Transcribe / Test / Operate",
+  },
 }
 
 export const EVIDENCE_DOSSIER_PROJECT_IDS = Object.freeze(

--- a/app/projects/[id]/projectMedia.ts
+++ b/app/projects/[id]/projectMedia.ts
@@ -308,27 +308,27 @@ const PROJECT_MEDIA_COPY: Record<string, Record<string, ProjectMediaCopy>> = {
   },
   transcribe: {
     "/projects/transcribe/main-image.png": {
-      label: "Drive-through transcription prototype",
-      caption: "Primary accessibility tool for real-time speech-to-text in high-traffic retail operations.",
+      label: "Drive-through transcription system",
+      caption: "The partner-facing display transcribes a customer order beside the existing point-of-sale workflow, making the accessibility concept inspectable in its retail context.",
     },
     "/projects/transcribe/situation.png": {
-      label: "Retail communication context",
-      caption: "Situation artifact showing the communication gap this accessibility workflow addressed.",
+      label: "Communication roadmap and pilot plan",
+      caption: "The project brief connects noisy drive-through communication, a speech-to-text hypothesis, partner and customer needs, hardware constraints, and a bounded store-test plan.",
       section: "situation",
     },
     "/projects/transcribe/action.png": {
-      label: "Prototype and interface work",
-      caption: "Design and build evidence for the real-time transcription workflow.",
+      label: "Interface and implementation record",
+      caption: "The action record documents accessibility research, MVP and stretch flows, React development, and Google Cloud Speech-to-Text integration.",
       section: "action",
     },
     "/projects/transcribe/testing.png": {
-      label: "Usability testing",
-      caption: "Testing evidence used to validate the tool with accessibility and operational needs.",
+      label: "Listening-state and in-store testing",
+      caption: "Muted and listening states are paired with an in-store usability review, preserving both interface behavior and the physical counter environment used for evaluation.",
       section: "action",
     },
     "/projects/transcribe/result.png": {
-      label: "Deployment outcome",
-      caption: "Result artifact tying the transcription workflow to accuracy and efficiency improvements.",
+      label: "Documented pilot outcomes",
+      caption: "The case-study record reports a 30% transcription-accuracy improvement and a 50% reduction in manual note-taking time alongside in-store pilot evidence.",
       section: "result",
     },
   },

--- a/design-qa-transcribe.md
+++ b/design-qa-transcribe.md
@@ -1,0 +1,50 @@
+# Transcribe Evidence Dossier Design QA
+
+## Reference
+
+- Production baseline: `/tmp/transcribe-production-before.png`
+- Evidence dossier implementation: `/tmp/transcribe-dossier-desktop-viewport.png`
+- Side-by-side comparison: `/tmp/transcribe-dossier-comparison.png`
+- Mobile implementation: `/tmp/transcribe-dossier-mobile.png`
+- Mobile outcome evidence: `/tmp/transcribe-dossier-mobile-outcomes.png`
+- Reviewed repository artifact sheet: `/tmp/transcribe-assets-contact-sheet.png`
+- Mobile viewport: 390 x 844
+
+## Product Intent
+
+This slice applies the shared evidence-dossier system to Transcribe. The page now presents an accessible voice-interaction workflow from communication framing and hardware constraints through React implementation, Speech-to-Text integration, in-store testing, and attributed pilot outcomes.
+
+## Implementation Review
+
+- Transcribe now uses the shared dossier structure established by the prior five case files.
+- Five repository artifacts document the communication roadmap, interface work, implementation, testing, store context, and outcomes.
+- The public proof role distinguishes accessibility UX, voice interaction, React development, and field validation.
+- The previous broad seamless-deployment and satisfaction language was replaced with bounded pilot evidence.
+- The 30% transcription-accuracy and 50% note-taking metrics remain explicitly attributed to the case-study record.
+- The shared artifact viewer now eagerly loads its small supporting thumbnails so compact layouts do not show blank evidence tiles.
+
+## Visual Review
+
+- The first viewport gives Transcribe, Starbucks, the implementation role, artifact count, and capabilities a clear hierarchy.
+- The physical counter setup remains the primary artifact and keeps the transcription display beside the point-of-sale workflow.
+- Supporting media preserves the roadmap, MVP flows, interface states, in-store review, and outcome record.
+- Evidence strips place communication framing, build evidence, testing, and outcomes beside the claims they support.
+- The mobile layout has one H1, no horizontal overflow, and clean stacking across the hero, artifact viewer, case index, sections, and evidence cards.
+- All section evidence and supporting thumbnails resolve after the shared loading fix.
+
+## Interaction And Accessibility
+
+- The page preserves one semantic H1 and ordered H2 sections.
+- The case index remains a semantic navigation landmark with anchored section links.
+- The primary artifact viewer opens and closes correctly with accessible button and dialog names.
+- Existing keyboard focus, captions, reduced-motion behavior, and media controls remain intact.
+- Desktop and mobile browser review found no page-origin console errors.
+
+## Validation
+
+- `pnpm test`: 89 tests passed
+- `pnpm lint`: passed
+- `pnpm check:links`: passed
+- `pnpm build`: passed
+
+final result: passed

--- a/public/data/projects.json
+++ b/public/data/projects.json
@@ -475,7 +475,7 @@
   "transcribe": {
     "title": "Transcribe",
     "category": "design",
-    "description": "Starbucks sought to improve communication in their stores, particularly in drive-through scenarios, by implementing real-time speech-to-text transcription. This initiative aimed to enhance inclusivity and operational efficiency. As the Product UX/UI Designer and React Developer, I designed and developed the Transcribe application to address unique communication challenges in high-traffic retail environments.",
+    "description": "Designed and built a React speech-to-text workflow for Starbucks drive-throughs, combining partner-facing transcription, accessibility research, interface prototyping, and in-store evaluation.",
     "image": "/projects/transcribe/main-image.png",
     "technologies": [
       "React.js",
@@ -495,36 +495,73 @@
       "client": "Starbucks Corporation",
       "date": "Dec 15, 2022",
       "category": "Design Engineering",
+      "proofRole": "Direct implementation evidence for accessible voice interaction in a high-traffic retail workflow, from research and interface design through React development and in-store testing.",
       "services": [
-        "Experience Design",
-        "Accessibility Solutions",
-        "Emerging Technologies"
+        "Accessibility UX",
+        "Voice Interaction",
+        "React Development",
+        "Field Validation"
       ],
-      "situation": "Starbucks sought to improve communication in their stores, particularly in drive-through scenarios, by implementing real-time speech-to-text transcription. This initiative aimed to enhance inclusivity and operational efficiency.",
-      "task": "As the Product UX/UI Designer and React Developer, my responsibility was to design and develop the Transcribe application. The goal was to address unique communication challenges in high-traffic retail environments and ensure the tool was effective and user-friendly.",
-      "actions": [
+      "situation": [
         {
-          "title": "User Research",
-          "description": "Conducted user research to understand the needs of Starbucks employees and customers, especially focusing on individuals with disabilities."
+          "title": "Noise Interrupted Drive-Through Communication",
+          "description": "The project brief identifies noisy store environments, acoustic accessibility barriers, and high demand from retail partners as recurring causes of communication friction."
         },
         {
-          "title": "Design",
-          "description": "Created wireframes and prototypes using Figma, ensuring the interface was intuitive and accessible."
+          "title": "Partners and Customers Shared the Workflow",
+          "description": "A customer order had to become readable speech-to-text at the point of sale while preserving a fast partner-facing interaction inside an existing drive-through process."
         },
         {
-          "title": "Development",
-          "description": "Developed the application using React.js and integrated it with Google Cloud's Speech-to-Text API for real-time transcription."
-        },
-        {
-          "title": "Testing",
-          "description": "Conducted rigorous testing, including usability testing with individuals with disabilities, to ensure the tool met diverse needs."
-        },
-        {
-          "title": "Integration",
-          "description": "Integrated the application into Starbucks' existing operational framework, ensuring seamless deployment."
+          "title": "The Pilot Had Physical Constraints",
+          "description": "The concept paired a customer microphone, partner touchscreen, Dell display, and existing point-of-sale station, so interface decisions had to work within a real counter setup."
         }
       ],
-      "result": "The Transcribe initiative significantly enhanced customer satisfaction and operational fluidity. It improved transcription accuracy by 30% and reduced manual note-taking time by 50%. This project showcased my expertise in UX/UI design and development and emphasized my commitment to creating accessible and inclusive digital solutions."
+      "task": [
+        {
+          "title": "Make Speech Visible in Real Time",
+          "description": "Create a transcription experience that let partners confirm customer orders without relying only on noisy audio or manual note-taking."
+        },
+        {
+          "title": "Design for Accessible Control",
+          "description": "Make listening, muted, correction, confirmation, and order states legible for people with different communication needs."
+        },
+        {
+          "title": "Validate the Retail Workflow",
+          "description": "Move beyond a standalone interface by testing the product in the store environment and evaluating how it fit the partner and customer interaction."
+        }
+      ],
+      "actions": [
+        {
+          "title": "Researched Accessibility Needs",
+          "description": "Studied partner and customer communication needs with explicit attention to people with disabilities and the constraints of high-traffic retail environments."
+        },
+        {
+          "title": "Designed MVP and Stretch Flows",
+          "description": "Created Figma flows for ordering, transcription, microphone control, confirmation, and completion states across a bounded MVP and expanded interaction model."
+        },
+        {
+          "title": "Built the Transcription Application",
+          "description": "Developed the interface in React and integrated Google Cloud Speech-to-Text so spoken customer orders could appear on the partner-facing display in real time."
+        },
+        {
+          "title": "Tested Interface and Store Context",
+          "description": "Reviewed muted and listening states, conducted usability testing with people with disabilities, and evaluated the prototype inside a physical Starbucks counter workflow."
+        }
+      ],
+      "results": [
+        {
+          "title": "30% Transcription-Accuracy Improvement",
+          "description": "The case-study record reports the measured improvement after the speech-to-text workflow was refined and evaluated."
+        },
+        {
+          "title": "50% Less Manual Note-Taking Time",
+          "description": "The documented outcome connects real-time transcription with reduced dependence on manual note capture during the retail interaction."
+        },
+        {
+          "title": "In-Context Pilot Evidence",
+          "description": "The evidence set shows the partner display operating beside the point-of-sale system and staff reviewing the experience at the store counter."
+        }
+      ]
     }
   },
   "geovoice": {


### PR DESCRIPTION
## Summary
- apply the shared evidence-dossier presentation to Transcribe
- connect communication framing, accessibility research, React and Speech-to-Text implementation, in-store testing, and attributed outcomes
- replace broad deployment language with bounded pilot evidence
- ensure supporting artifact thumbnails load reliably in compact layouts
- add Transcribe-specific contract and design QA

## Evidence
- cognitive communication roadmap and bounded store-test plan
- MVP and stretch interaction flows
- React and Google Cloud Speech-to-Text implementation record
- muted/listening states and in-store evaluation
- documented 30% accuracy and 50% note-taking outcomes

## Validation
- `pnpm test` (89 tests, including type-check)
- `pnpm lint`
- `pnpm check:links`
- `pnpm build`
- desktop and 390 x 844 browser QA
- supporting-thumbnail and fullscreen viewer QA