### PR TITLE
Add evidence-driven dossier exit paths

### DIFF
--- a/__tests__/dossier-exit-path.test.ts
+++ b/__tests__/dossier-exit-path.test.ts
@@ -1,0 +1,47 @@
+import { PROJECTS } from "../data/projects"
+import {
+  buildProjectFocusHref,
+  getDossierExitPath,
+  getProjectCapabilities,
+  getRelatedEvidenceRoutes,
+} from "../app/projects/[id]/dossierExitPathData"
+import { decodeAdaptiveFocusBriefHandoff } from "../features/adaptive-focus/handoff"
+
+describe("evidence dossier exit path", () => {
+  it.each(PROJECTS.map((project) => project.id))(
+    "%s receives two deterministic related evidence routes",
+    (projectId) => {
+      const first = getRelatedEvidenceRoutes(projectId)
+      const second = getRelatedEvidenceRoutes(projectId)
+
+      expect(first).toEqual(second)
+      expect(first).toHaveLength(2)
+      expect(first.every((project) => project.projectId !== projectId)).toBe(true)
+      expect(first.every((project) => project.sharedCapabilities.length > 0)).toBe(true)
+    }
+  )
+
+  it("routes Astrocade through reviewed human-in-the-loop evidence", () => {
+    const exitPath = getDossierExitPath("astrocade-qa-calibration-tool")
+
+    expect(exitPath.capabilities).toEqual(
+      expect.arrayContaining(["human-in-the-loop-ai", "evaluation-calibration", "moderation-qa"])
+    )
+    expect(exitPath.relatedProjects.map((project) => project.projectId)).toContain("petition-ready")
+  })
+
+  it("encodes capabilities as a versioned Adaptive Focus handoff", () => {
+    const capabilities = getProjectCapabilities("speakeasy").slice(0, 4)
+    const href = buildProjectFocusHref(capabilities)
+    const url = new URL(href, "https://mikechaves.io")
+    const token = url.searchParams.get("focusBrief")
+    const decoded = token ? decodeAdaptiveFocusBriefHandoff(token) : null
+
+    expect(url.pathname).toBe("/projects")
+    expect(url.hash).toBe("#adaptive-focus-controls-heading")
+    expect(decoded?.analysisSource).toBe("preset")
+    expect(decoded?.interpretation.requirements.map((requirement) => requirement.capability)).toEqual(
+      capabilities
+    )
+  })
+})

--- a/app/globals.css
+++ b/app/globals.css
@@ -674,6 +674,178 @@ textarea {
   border-top: 2px solid rgba(0, 255, 140, 0.55);
 }
 
+.dossier-exit-path {
+  border-block: 1px solid rgba(255, 255, 255, 0.14);
+  background:
+    linear-gradient(110deg, rgba(0, 255, 140, 0.055), transparent 45%),
+    rgba(0, 0, 0, 0.76);
+}
+
+.dossier-exit-status {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem 1.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 0.55rem 0.85rem;
+  color: rgb(113 113 122);
+  font-size: 0.58rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.dossier-exit-status span:nth-child(2) {
+  color: #00ff8c;
+}
+
+.dossier-exit-grid {
+  display: grid;
+  gap: 2rem;
+  padding: clamp(1.4rem, 3.5vw, 3rem) clamp(1rem, 2.7vw, 2.75rem);
+}
+
+.dossier-exit-intro h2 {
+  margin-top: 0.45rem;
+  color: #ffffff;
+  font-family: var(--font-display), sans-serif;
+  font-size: clamp(2.35rem, 4.5vw, 4.5rem);
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 0.92;
+  text-transform: uppercase;
+}
+
+.dossier-exit-intro > p:not(.dossier-section-kicker) {
+  max-width: 38rem;
+  margin-top: 1rem;
+  color: rgb(161 161 170);
+  font-size: 0.88rem;
+  line-height: 1.65;
+}
+
+.dossier-exit-capabilities {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 1.25rem;
+}
+
+.dossier-exit-capabilities span {
+  border: 1px solid rgba(0, 255, 140, 0.25);
+  padding: 0.35rem 0.5rem;
+  color: rgb(161 161 170);
+  font-size: 0.58rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.dossier-related-evidence > p {
+  margin-bottom: 0.45rem;
+  color: rgb(113 113 122);
+  font-size: 0.62rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.dossier-related-evidence > a {
+  display: grid;
+  grid-template-columns: 2rem minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 4.6rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  color: rgb(228 228 231);
+  transition: border-color 160ms ease, color 160ms ease, background-color 160ms ease;
+}
+
+.dossier-related-evidence > a:last-child {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.dossier-related-evidence > a:hover,
+.dossier-related-evidence > a:focus-visible {
+  border-color: rgba(0, 255, 140, 0.5);
+  background: rgba(0, 255, 140, 0.035);
+  color: #00ff8c;
+}
+
+.dossier-related-index {
+  color: rgb(82 82 91);
+  font-size: 0.62rem;
+}
+
+.dossier-related-evidence strong,
+.dossier-related-evidence small,
+.dossier-exit-primary-action strong,
+.dossier-exit-primary-action small {
+  display: block;
+}
+
+.dossier-related-evidence strong {
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.dossier-related-evidence small {
+  margin-top: 0.3rem;
+  color: rgb(113 113 122);
+  font-size: 0.62rem;
+  line-height: 1.45;
+}
+
+.dossier-exit-actions {
+  display: grid;
+  align-content: start;
+  gap: 0.6rem;
+}
+
+.dossier-exit-actions > a {
+  display: flex;
+  min-height: 2.8rem;
+  align-items: center;
+  gap: 0.65rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  padding: 0.7rem 0.8rem;
+  color: rgb(212 212 216);
+  font-size: 0.68rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  transition: border-color 160ms ease, color 160ms ease, background-color 160ms ease;
+}
+
+.dossier-exit-actions > a:hover,
+.dossier-exit-actions > a:focus-visible {
+  border-color: rgba(0, 255, 140, 0.55);
+  color: #00ff8c;
+}
+
+.dossier-exit-actions > .dossier-exit-primary-action {
+  min-height: 4.6rem;
+  border-color: rgba(0, 255, 140, 0.42);
+  background: rgba(0, 255, 140, 0.08);
+  color: #00ff8c;
+}
+
+.dossier-exit-primary-action > span {
+  min-width: 0;
+  flex: 1;
+}
+
+.dossier-exit-primary-action strong {
+  font-size: 0.72rem;
+}
+
+.dossier-exit-primary-action small {
+  margin-top: 0.25rem;
+  color: rgb(161 161 170);
+  font-size: 0.58rem;
+  line-height: 1.45;
+  letter-spacing: 0.04em;
+  text-transform: none;
+}
+
 @media (min-width: 1024px) {
   .evidence-dossier-hero-grid {
     grid-template-columns: minmax(0, 1.6fr) minmax(18rem, 0.7fr);
@@ -687,6 +859,11 @@ textarea {
   .evidence-dossier-index {
     position: sticky;
     top: 6rem;
+  }
+
+  .dossier-exit-grid {
+    grid-template-columns: minmax(0, 1.05fr) minmax(18rem, 0.95fr) minmax(17rem, 0.7fr);
+    align-items: start;
   }
 }
 
@@ -714,6 +891,15 @@ textarea {
 
   .evidence-dossier-sections .case-study-detail-card + .case-study-detail-card {
     padding-left: 0;
+  }
+
+  .dossier-exit-status span:last-child {
+    display: none;
+  }
+
+  .dossier-exit-intro h2 {
+    overflow-wrap: anywhere;
+    font-size: 2.35rem;
   }
 }
 

--- a/app/projects/[id]/DossierExitPath.tsx
+++ b/app/projects/[id]/DossierExitPath.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import Link from "next/link"
+import { ArrowRight, Download, FileSearch2, MessageSquareText } from "lucide-react"
+import type { DossierExitPath as DossierExitPathData } from "./dossierExitPathData"
+
+export function DossierExitPath({
+  exitPath,
+  projectTitle,
+}: {
+  exitPath: DossierExitPathData
+  projectTitle: string
+}) {
+  return (
+    <section className="dossier-exit-path" aria-labelledby="dossier-exit-title">
+      <div className="dossier-exit-status" aria-hidden="true">
+        <span>NEXT SIGNAL / EVIDENCE ROUTING</span>
+        <span>ROLE FIT / READY</span>
+        <span>CONTACT / OPEN</span>
+      </div>
+
+      <div className="dossier-exit-grid">
+        <div className="dossier-exit-intro">
+          <p className="dossier-section-kicker">Continue the evidence trail</p>
+          <h2 id="dossier-exit-title">From proof to role fit</h2>
+          <p>
+            Compare {projectTitle} with adjacent systems, or carry its reviewed capabilities into an
+            Adaptive Focus brief.
+          </p>
+          <div className="dossier-exit-capabilities" aria-label="Capabilities carried into Adaptive Focus">
+            {exitPath.capabilityLabels.map((label) => (
+              <span key={label}>{label}</span>
+            ))}
+          </div>
+        </div>
+
+        <div className="dossier-related-evidence" aria-label="Related project evidence">
+          <p>Related evidence</p>
+          {exitPath.relatedProjects.map((related, index) => (
+            <Link key={related.projectId} href={`/projects/${related.projectId}`}>
+              <span className="dossier-related-index">0{index + 1}</span>
+              <span>
+                <strong>{related.title}</strong>
+                <small>
+                  {related.sharedCapabilities.length > 0
+                    ? `Shared evidence / ${related.sharedCapabilityLabels.join(" + ")}`
+                    : "Continue through the reviewed project archive"}
+                </small>
+              </span>
+              <ArrowRight size={16} aria-hidden="true" />
+            </Link>
+          ))}
+        </div>
+
+        <div className="dossier-exit-actions" aria-label="Role fit and contact actions">
+          <Link href={exitPath.focusHref} className="dossier-exit-primary-action">
+            <FileSearch2 size={17} aria-hidden="true" />
+            <span>
+              <strong>Build Role Fit Brief</strong>
+              <small>Carry these capabilities into Adaptive Focus</small>
+            </span>
+            <ArrowRight size={16} aria-hidden="true" />
+          </Link>
+          <Link href="/about#contact-title">
+            <MessageSquareText size={17} aria-hidden="true" />
+            Start a conversation
+          </Link>
+          <a href="/Michael_Chaves_Resume_min.pdf" download>
+            <Download size={17} aria-hidden="true" />
+            Download resume
+          </a>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/projects/[id]/ProjectPageClient.tsx
+++ b/app/projects/[id]/ProjectPageClient.tsx
@@ -6,6 +6,8 @@ import { useState, useCallback, useEffect, useMemo } from "react"
 import type { ReactNode } from "react"
 import { ImageModal } from "@/components/image-modal"
 import type { Project as ProjectSummary } from "@/types/project"
+import { DossierExitPath } from "./DossierExitPath"
+import type { DossierExitPath as DossierExitPathData } from "./dossierExitPathData"
 import { ProjectEvidenceStrip } from "./ProjectEvidenceStrip"
 import { ProjectMediaShowcase } from "./ProjectMediaShowcase"
 import { getEvidenceDossierConfig } from "./dossierConfig"
@@ -51,6 +53,7 @@ interface Project {
 }
 
 interface ProjectPageClientProps {
+  dossierExitPath: DossierExitPathData
   project: Project
 }
 
@@ -97,7 +100,7 @@ function DetailItemCard({ item, marker }: { item: DetailItem; marker: string }) 
   )
 }
 
-export default function ProjectPageClient({ project }: ProjectPageClientProps) {
+export default function ProjectPageClient({ dossierExitPath, project }: ProjectPageClientProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
   const dossierConfig = getEvidenceDossierConfig(project.id)
   const isEvidenceDossier = Boolean(dossierConfig)
@@ -396,6 +399,9 @@ export default function ProjectPageClient({ project }: ProjectPageClientProps) {
       )}
         </div>
       </div>
+      {isEvidenceDossier && (
+        <DossierExitPath exitPath={dossierExitPath} projectTitle={project.title} />
+      )}
       <ImageModal
         open={selectedIndex !== null}
         onOpenChange={(o) => !o && closeModal()}

--- a/app/projects/[id]/dossierExitPathData.ts
+++ b/app/projects/[id]/dossierExitPathData.ts
@@ -1,0 +1,132 @@
+import { PROJECTS } from "@/data/projects"
+import { PROJECT_EVIDENCE } from "@/features/adaptive-focus/evidence/catalog"
+import { encodeAdaptiveFocusInterpretationHandoff } from "@/features/adaptive-focus/handoff"
+import type { ProjectEvidence } from "@/features/adaptive-focus/types"
+import { CAPABILITY_LABELS, type AdaptiveCapability } from "@/packages/adaptive-focus-core/src"
+
+const CONFIDENCE_WEIGHT: Record<ProjectEvidence["confidence"], number> = {
+  direct: 3,
+  supporting: 2,
+  adjacent: 1,
+}
+
+const MAX_FOCUS_CAPABILITIES = 4
+const MAX_RELATED_PROJECTS = 2
+
+export interface RelatedEvidenceRoute {
+  projectId: string
+  title: string
+  description: string
+  sharedCapabilities: AdaptiveCapability[]
+  sharedCapabilityLabels: string[]
+}
+
+export interface DossierExitPath {
+  capabilities: AdaptiveCapability[]
+  capabilityLabels: string[]
+  focusHref: string
+  relatedProjects: RelatedEvidenceRoute[]
+}
+
+function capabilityWeights(projectId: string, evidence: ProjectEvidence[]) {
+  const weights = new Map<AdaptiveCapability, number>()
+
+  evidence.forEach((item) => {
+    if (item.projectId !== projectId) return
+    weights.set(
+      item.capability,
+      Math.max(weights.get(item.capability) ?? 0, CONFIDENCE_WEIGHT[item.confidence])
+    )
+  })
+
+  return weights
+}
+
+export function getProjectCapabilities(
+  projectId: string,
+  evidence: ProjectEvidence[] = PROJECT_EVIDENCE
+): AdaptiveCapability[] {
+  const weights = capabilityWeights(projectId, evidence)
+  return [...weights.entries()]
+    .sort((left, right) => right[1] - left[1])
+    .map(([capability]) => capability)
+}
+
+export function getRelatedEvidenceRoutes(
+  projectId: string,
+  evidence: ProjectEvidence[] = PROJECT_EVIDENCE
+): RelatedEvidenceRoute[] {
+  const sourceWeights = capabilityWeights(projectId, evidence)
+  const canonicalIndex = new Map(PROJECTS.map((project, index) => [project.id, index]))
+
+  return PROJECTS.filter((project) => project.id !== projectId)
+    .map((project) => {
+      const candidateWeights = capabilityWeights(project.id, evidence)
+      const sharedCapabilities = [...sourceWeights.keys()].filter((capability) =>
+        candidateWeights.has(capability)
+      )
+      const score = sharedCapabilities.reduce(
+        (total, capability) =>
+          total + Math.min(sourceWeights.get(capability) ?? 0, candidateWeights.get(capability) ?? 0),
+        0
+      )
+
+      return {
+        ...project,
+        score,
+        sharedCapabilities,
+      }
+    })
+    .sort(
+      (left, right) =>
+        right.score - left.score ||
+        (canonicalIndex.get(left.id) ?? Number.MAX_SAFE_INTEGER) -
+          (canonicalIndex.get(right.id) ?? Number.MAX_SAFE_INTEGER)
+    )
+    .slice(0, MAX_RELATED_PROJECTS)
+    .map((project) => ({
+      projectId: project.id,
+      title: project.title,
+      description: project.description,
+      sharedCapabilities: project.sharedCapabilities,
+      sharedCapabilityLabels: project.sharedCapabilities.map(
+        (capability) => CAPABILITY_LABELS[capability]
+      ),
+    }))
+}
+
+export function buildProjectFocusHref(capabilities: AdaptiveCapability[]): string {
+  const selectedCapabilities = capabilities.slice(0, MAX_FOCUS_CAPABILITIES)
+  const interpretation = {
+    normalizedInput: selectedCapabilities.map((capability) => CAPABILITY_LABELS[capability]).join(", "),
+    roleTitle: null,
+    roleFamily: "unknown" as const,
+    seniority: "unspecified" as const,
+    companyContext: null,
+    requirements: selectedCapabilities.map((capability) => ({
+      capability,
+      importance: "preferred" as const,
+      basis: "explicit" as const,
+    })),
+    responsibilities: [],
+    desiredOutcomes: [],
+    confidence: selectedCapabilities.length > 0 ? 1 : 0,
+    clarificationNeeded: selectedCapabilities.length === 0,
+    clarificationQuestion:
+      selectedCapabilities.length === 0
+        ? "Add a role, capability, or workflow so Adaptive Focus can build a grounded brief."
+        : null,
+  }
+  const token = encodeAdaptiveFocusInterpretationHandoff(interpretation, "preset")
+  return `/projects?focusBrief=${encodeURIComponent(token)}#adaptive-focus-controls-heading`
+}
+
+export function getDossierExitPath(projectId: string): DossierExitPath {
+  const capabilities = getProjectCapabilities(projectId).slice(0, MAX_FOCUS_CAPABILITIES)
+  return {
+    capabilities,
+    capabilityLabels: capabilities.map((capability) => CAPABILITY_LABELS[capability]),
+    focusHref: buildProjectFocusHref(capabilities),
+    relatedProjects: getRelatedEvidenceRoutes(projectId),
+  }
+}

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs'
 import path from 'path'
 import { redirect } from 'next/navigation'
 import ProjectPageClient from './ProjectPageClient'
+import { getDossierExitPath } from './dossierExitPathData'
 
 interface ProjectPageProps {
   params: Promise<{ id: string }>
@@ -17,5 +18,5 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
     redirect('/error?message=' + encodeURIComponent('Project not found'))
   }
   const project = { id, ...p }
-  return <ProjectPageClient project={project} />
+  return <ProjectPageClient dossierExitPath={getDossierExitPath(id)} project={project} />
 }

--- a/features/adaptive-focus/handoff.ts
+++ b/features/adaptive-focus/handoff.ts
@@ -93,18 +93,25 @@ const IMPORTANCE = new Set(["required", "preferred", "context"])
 const BASIS = new Set(["explicit", "inferred"])
 
 export function encodeAdaptiveFocusBriefHandoff(result: AdaptiveFocusV2Result): string {
+  return encodeAdaptiveFocusInterpretationHandoff(result.interpretation, result.analysisSource)
+}
+
+export function encodeAdaptiveFocusInterpretationHandoff(
+  interpretation: RoleInterpretation,
+  analysisSource: AdaptiveFocusAnalysisSource
+): string {
   const payload: BriefHandoffPayload = {
     v: 2,
-    source: result.analysisSource,
-    family: result.interpretation.roleFamily,
-    seniority: result.interpretation.seniority,
-    requirements: result.interpretation.requirements.map((requirement) => [
+    source: analysisSource,
+    family: interpretation.roleFamily,
+    seniority: interpretation.seniority,
+    requirements: interpretation.requirements.map((requirement) => [
       requirement.capability,
       requirement.importance,
       requirement.basis,
     ]),
-    confidence: result.interpretation.confidence,
-    clarification: result.interpretation.clarificationNeeded,
+    confidence: interpretation.confidence,
+    clarification: interpretation.clarificationNeeded,
   }
   return btoa(JSON.stringify(payload)).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/u, "")
 }


### PR DESCRIPTION
## Summary
- add a shared post-dossier exit path across all 15 active project case studies
- rank two related projects from overlapping reviewed Adaptive Focus evidence with stable canonical ties
- carry the current project's strongest capabilities into a versioned Role Fit Brief handoff
- add direct conversation and resume actions without introducing a new landing page
- compute evidence routing on the server so the project-page client bundle remains near baseline

## Visual QA
- compared the production Astrocade ending with the new evidence-routing end-cap at the same desktop state
- verified the 390px stack with no horizontal overflow
- verified Astrocade routes to PetitionReady through shared reviewed evidence
- verified the Role Fit handoff reconstructs human-in-the-loop AI, evaluation, moderation, and operational UX capabilities
- verified the optimized local route after the production build and dev-server restart

## Validation
- `pnpm type-check`
- `pnpm test` (24 suites, 136 tests)
- `pnpm check:links` (253 assets, 53 internal routes)
- `pnpm lint`
- `pnpm build`
- project detail first-load JS: 186 kB (185 kB baseline; 219 kB intermediate client-heavy implementation rejected)
