### PR TITLE
Preserve route context in the global shell

### DIFF
--- a/__tests__/global-route-context.test.ts
+++ b/__tests__/global-route-context.test.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs"
+import path from "node:path"
+import { getRouteTransitionState } from "../components/route-transition-state"
+import { isSiteNavItemActive, SITE_NAV_ITEMS } from "../components/site-nav-state"
+
+describe("global route context", () => {
+  it.each([
+    ["/", "/", true],
+    ["/projects", "/projects", true],
+    ["/projects/astrocade-qa-calibration-tool", "/projects", true],
+    ["/blog/voice-first-xr", "/blog", true],
+    ["/about", "/about", true],
+    ["/archive", "/", false],
+    ["/project", "/projects", false],
+    ["/blogroll", "/blog", false],
+  ])("matches %s against %s as %s", (pathname, itemPath, expected) => {
+    expect(isSiteNavItemActive(pathname, itemPath)).toBe(expected)
+  })
+
+  it("keeps the four public navigation destinations stable", () => {
+    expect(SITE_NAV_ITEMS).toEqual([
+      { name: "impact", path: "/" },
+      { name: "systems", path: "/projects" },
+      { name: "writing", path: "/blog" },
+      { name: "about", path: "/about" },
+    ])
+  })
+
+  it("removes movement and blur when reduced motion is requested", () => {
+    const reduced = getRouteTransitionState(true)
+
+    expect(reduced.initial).toBe(false)
+    expect(reduced.animate).toEqual({ opacity: 1 })
+    expect(reduced.exit).toEqual({ opacity: 1 })
+    expect(reduced.transition).toEqual({ duration: 0 })
+  })
+
+  it("preserves the existing signal transition otherwise", () => {
+    const standard = getRouteTransitionState(false)
+
+    expect(standard.initial).toEqual({ opacity: 0, y: 10, filter: "blur(6px)" })
+    expect(standard.animate).toEqual({ opacity: 1, y: 0, filter: "blur(0px)" })
+    expect(standard.exit).toEqual({ opacity: 0, y: -8, filter: "blur(4px)" })
+    expect(standard.transition.duration).toBe(0.28)
+  })
+
+  it("publishes active-route and mobile-menu semantics", () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, "..", "components", "site-nav.tsx"),
+      "utf8"
+    )
+
+    expect(source.match(/aria-current=\{isActive \? "page" : undefined\}/gu)).toHaveLength(2)
+    expect(source).toContain('aria-controls="site-mobile-menu"')
+    expect(source).toContain('aria-label="Mobile navigation"')
+    expect(source).toContain("setIsMobileMenuOpen(false)")
+  })
+})

--- a/components/route-transition-state.ts
+++ b/components/route-transition-state.ts
@@ -1,0 +1,19 @@
+const STANDARD_EASING = [0.22, 1, 0.36, 1] as const
+
+export function getRouteTransitionState(shouldReduceMotion: boolean | null) {
+  if (shouldReduceMotion) {
+    return {
+      initial: false as const,
+      animate: { opacity: 1 },
+      exit: { opacity: 1 },
+      transition: { duration: 0 },
+    }
+  }
+
+  return {
+    initial: { opacity: 0, y: 10, filter: "blur(6px)" },
+    animate: { opacity: 1, y: 0, filter: "blur(0px)" },
+    exit: { opacity: 0, y: -8, filter: "blur(4px)" },
+    transition: { duration: 0.28, ease: STANDARD_EASING },
+  }
+}

--- a/components/route-transition.tsx
+++ b/components/route-transition.tsx
@@ -1,20 +1,20 @@
 "use client"
 
-import { AnimatePresence, motion } from "framer-motion"
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion"
 import { usePathname } from "next/navigation"
 import type React from "react"
+import { getRouteTransitionState } from "./route-transition-state"
 
 export function RouteTransition({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
+  const shouldReduceMotion = useReducedMotion()
+  const transitionState = getRouteTransitionState(shouldReduceMotion)
 
   return (
     <AnimatePresence mode="wait" initial={false}>
       <motion.div
         key={pathname}
-        initial={{ opacity: 0, y: 10, filter: "blur(6px)" }}
-        animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
-        exit={{ opacity: 0, y: -8, filter: "blur(4px)" }}
-        transition={{ duration: 0.28, ease: [0.22, 1, 0.36, 1] }}
+        {...transitionState}
       >
         {children}
       </motion.div>

--- a/components/site-nav-state.ts
+++ b/components/site-nav-state.ts
@@ -1,0 +1,16 @@
+export interface SiteNavItem {
+  name: string
+  path: string
+}
+
+export const SITE_NAV_ITEMS: SiteNavItem[] = [
+  { name: "impact", path: "/" },
+  { name: "systems", path: "/projects" },
+  { name: "writing", path: "/blog" },
+  { name: "about", path: "/about" },
+]
+
+export function isSiteNavItemActive(pathname: string, itemPath: string): boolean {
+  if (itemPath === "/") return pathname === "/"
+  return pathname === itemPath || pathname.startsWith(`${itemPath}/`)
+}

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -3,21 +3,18 @@
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import type { MouseEvent } from "react"
-import { useMemo, useState } from "react"
+import { useEffect, useState } from "react"
 import { ArrowUpRight, Menu, X } from "lucide-react"
+import { isSiteNavItemActive, SITE_NAV_ITEMS } from "./site-nav-state"
 
 export function SiteNav() {
   const pathname = usePathname()
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
-  const navItems = useMemo(
-    () => [
-      { name: "impact", path: "/" },
-      { name: "systems", path: "/projects" },
-      { name: "writing", path: "/blog" },
-      { name: "about", path: "/about" },
-    ],
-    [],
-  )
+
+  useEffect(() => {
+    setIsMobileMenuOpen(false)
+  }, [pathname])
+
   const enterMetaverse = (event: MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault()
     window.location.assign("/?metaverse=true")
@@ -45,18 +42,22 @@ export function SiteNav() {
             </Link>
 
             <ul className="hidden items-center justify-end gap-7 md:flex">
-              {navItems.map((item) => (
-                <li key={item.path}>
-                  <Link
-                    href={item.path}
-                    className={`signal-nav-link relative py-2 text-[0.7rem] uppercase tracking-[0.14em] transition-colors hover:text-primary ${
-                      pathname === item.path ? "text-primary" : "text-zinc-300"
-                    }`}
-                  >
-                    {item.name}
-                  </Link>
-                </li>
-              ))}
+              {SITE_NAV_ITEMS.map((item) => {
+                const isActive = isSiteNavItemActive(pathname, item.path)
+                return (
+                  <li key={item.path}>
+                    <Link
+                      href={item.path}
+                      aria-current={isActive ? "page" : undefined}
+                      className={`signal-nav-link relative py-2 text-[0.7rem] uppercase tracking-[0.14em] transition-colors hover:text-primary ${
+                        isActive ? "text-primary" : "text-zinc-300"
+                      }`}
+                    >
+                      {item.name}
+                    </Link>
+                  </li>
+                )
+              })}
             </ul>
 
             <button
@@ -64,6 +65,7 @@ export function SiteNav() {
               onClick={() => setIsMobileMenuOpen((isOpen) => !isOpen)}
               aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
               aria-expanded={isMobileMenuOpen}
+              aria-controls="site-mobile-menu"
             >
               {isMobileMenuOpen ? <X size={22} /> : <Menu size={22} />}
             </button>
@@ -72,7 +74,11 @@ export function SiteNav() {
       </header>
 
       {isMobileMenuOpen && (
-        <div className="border-b border-primary/25 bg-black/95 backdrop-blur-md md:hidden">
+        <nav
+          id="site-mobile-menu"
+          aria-label="Mobile navigation"
+          className="border-b border-primary/25 bg-black/95 backdrop-blur-md md:hidden"
+        >
           <ul className="site-shell space-y-px py-3">
             <li className="md:hidden">
               <Link
@@ -86,21 +92,27 @@ export function SiteNav() {
                 Enter Metaverse <ArrowUpRight size={14} aria-hidden="true" />
               </Link>
             </li>
-            {navItems.map((item) => (
-              <li key={item.path}>
-                <Link
-                  href={item.path}
-                  onClick={() => setIsMobileMenuOpen(false)}
-                  className={`block border-l-2 px-3 py-2 text-xs uppercase tracking-[0.14em] transition-colors ${
-                    pathname === item.path ? "border-primary bg-primary/10 text-primary" : "border-transparent text-white hover:border-primary/40 hover:text-primary"
-                  }`}
-                >
-                  {item.name}
-                </Link>
-              </li>
-            ))}
+            {SITE_NAV_ITEMS.map((item) => {
+              const isActive = isSiteNavItemActive(pathname, item.path)
+              return (
+                <li key={item.path}>
+                  <Link
+                    href={item.path}
+                    aria-current={isActive ? "page" : undefined}
+                    onClick={() => setIsMobileMenuOpen(false)}
+                    className={`block border-l-2 px-3 py-2 text-xs uppercase tracking-[0.14em] transition-colors ${
+                      isActive
+                        ? "border-primary bg-primary/10 text-primary"
+                        : "border-transparent text-white hover:border-primary/40 hover:text-primary"
+                    }`}
+                  >
+                    {item.name}
+                  </Link>
+                </li>
+              )
+            })}
           </ul>
-        </div>
+        </nav>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- keep Systems and Writing active on nested project and article routes without false-prefix matches
- publish `aria-current="page"` on active desktop and mobile navigation links
- close the mobile menu when pathname changes, including browser-history navigation
- connect the menu toggle to the mobile navigation landmark with `aria-controls`
- remove route movement and blur when reduced motion is requested
- hoist static navigation configuration and isolate route/motion behavior in pure tested helpers

## Visual and interaction QA
- compared the production and local project-detail navigation at the same desktop state
- verified nested Systems, nested Writing, exact About, and inactive false-prefix routes
- verified mobile menu active state at 390px with no horizontal overflow
- verified mobile menu closes after direct selection and browser-back route changes
- verified the rebuilt local dossier after the production build and dev-server restart

## Validation
- `pnpm type-check`
- `pnpm test` (25 suites, 148 tests)
- `pnpm check:links` (253 assets, 54 internal routes)
- `pnpm lint`
- `pnpm build`
- no measurable bundle-size change
