### PR TITLE
Calibrate project thumbnail framing

### DIFF
--- a/__tests__/project-thumbnails.test.ts
+++ b/__tests__/project-thumbnails.test.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs"
+import path from "node:path"
+import { getProjectThumbnailFocalPoint } from "@/data/project-thumbnails"
+import { PROJECTS } from "@/data/projects"
+import type { ProjectThumbnailFocalPoint } from "@/types/project"
+
+const VALID_FOCAL_POINTS = new Set<ProjectThumbnailFocalPoint>([
+  "center",
+  "top",
+  "bottom",
+  "left",
+  "right",
+])
+
+describe("project thumbnail framing", () => {
+  test("every canonical project resolves to a valid focal point", () => {
+    expect(PROJECTS).not.toHaveLength(0)
+
+    for (const project of PROJECTS) {
+      expect(VALID_FOCAL_POINTS.has(getProjectThumbnailFocalPoint(project.id))).toBe(true)
+      expect(project.thumbnailFocalPoint).toBe(getProjectThumbnailFocalPoint(project.id))
+    }
+  })
+
+  test("unknown projects retain centered framing", () => {
+    expect(getProjectThumbnailFocalPoint("future-project")).toBe("center")
+  })
+
+  test("Astrocade preserves the dashboard heading", () => {
+    expect(getProjectThumbnailFocalPoint("astrocade-qa-calibration-tool")).toBe("top")
+  })
+
+  test("the shared card keeps a consistent evidence frame", () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, "..", "components", "project-card.tsx"),
+      "utf8",
+    )
+
+    expect(source).toContain('className="relative aspect-[16/9]')
+    expect(source).not.toContain("lg:aspect-[16/7]")
+    expect(source).toContain("THUMBNAIL_OBJECT_POSITIONS[thumbnailFocalPoint]")
+  })
+})

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -400,6 +400,7 @@ export default function ProjectsPage() {
                 image={project.image}
                 technologies={project.technologies}
                 category={project.category}
+                thumbnailFocalPoint={project.thumbnailFocalPoint}
                 priority={index === 0}
               />
             </div>

--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -1,20 +1,36 @@
 import Image from "next/image"
 import Link from "next/link"
 import { ArrowUpRight } from "lucide-react"
-import type { Project } from "@/types/project"
+import type { Project, ProjectThumbnailFocalPoint } from "@/types/project"
 
 type ProjectCardProps = Project & {
   priority?: boolean
 }
 
-export function ProjectCard({ id, title, description, image, technologies, priority }: ProjectCardProps) {
+const THUMBNAIL_OBJECT_POSITIONS: Record<ProjectThumbnailFocalPoint, string> = {
+  center: "center",
+  top: "center top",
+  bottom: "center bottom",
+  left: "left center",
+  right: "right center",
+}
+
+export function ProjectCard({
+  id,
+  title,
+  description,
+  image,
+  technologies,
+  thumbnailFocalPoint = "center",
+  priority,
+}: ProjectCardProps) {
   return (
     <Link
       href={`/projects/${id}`}
       className="group block h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     >
       <article className="signal-project-card h-full overflow-hidden border border-white/15 bg-black/80 transition-colors group-hover:border-primary/60">
-        <div className="relative aspect-[16/9] min-h-44 overflow-hidden border-b border-white/10 bg-zinc-950 lg:aspect-[16/7]">
+        <div className="relative aspect-[16/9] min-h-44 overflow-hidden border-b border-white/10 bg-zinc-950">
           <Image
             src={
               image ||
@@ -23,6 +39,7 @@ export function ProjectCard({ id, title, description, image, technologies, prior
             alt={title}
             fill
             className="object-cover transition-transform duration-500 group-hover:scale-[1.025]"
+            style={{ objectPosition: THUMBNAIL_OBJECT_POSITIONS[thumbnailFocalPoint] }}
             sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
             priority={priority}
           />

--- a/components/role-fit-brief.tsx
+++ b/components/role-fit-brief.tsx
@@ -40,6 +40,7 @@ function ProjectProof({ match, priority = false }: { match: ProjectMatch; priori
         image={project.image}
         technologies={project.technologies}
         category={project.category}
+        thumbnailFocalPoint={project.thumbnailFocalPoint}
         priority={priority}
       />
       <div className="space-y-4 py-1">

--- a/data/project-thumbnails.ts
+++ b/data/project-thumbnails.ts
@@ -1,0 +1,13 @@
+import type { ProjectThumbnailFocalPoint } from "@/types/project"
+
+const PROJECT_THUMBNAIL_FOCAL_POINTS: Partial<
+  Record<string, ProjectThumbnailFocalPoint>
+> = {
+  "astrocade-qa-calibration-tool": "top",
+}
+
+export function getProjectThumbnailFocalPoint(
+  projectId: string,
+): ProjectThumbnailFocalPoint {
+  return PROJECT_THUMBNAIL_FOCAL_POINTS[projectId] ?? "center"
+}

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -1,4 +1,5 @@
 import rawProjects from "@/public/data/projects.json"
+import { getProjectThumbnailFocalPoint } from "@/data/project-thumbnails"
 import type { Project } from "@/types/project"
 
 type RawProjectRecord = {
@@ -17,6 +18,7 @@ const parsedProjects = Object.entries(rawProjects as Record<string, RawProjectRe
     image: `${project.image}?height=400&width=600`,
     technologies: project.technologies,
     category: project.category,
+    thumbnailFocalPoint: getProjectThumbnailFocalPoint(id),
   })
 )
 

--- a/types/project.ts
+++ b/types/project.ts
@@ -1,3 +1,5 @@
+export type ProjectThumbnailFocalPoint = "center" | "top" | "bottom" | "left" | "right"
+
 export interface Project {
   id: string
   title: string
@@ -5,4 +7,5 @@ export interface Project {
   image: string
   technologies: string[]
   category: 'design' | 'web' | 'research' | 'ar-vr' | 'development'
+  thumbnailFocalPoint?: ProjectThumbnailFocalPoint
 }


### PR DESCRIPTION
## Summary
- standardize project evidence cards on a 16:9 frame across desktop and mobile
- add typed per-project focal metadata with a top-aligned Astrocade calibration artifact
- propagate framing through the archive and Role Fit Brief, with regression coverage

## Validation
- pnpm test (152 tests)
- pnpm check:links
- pnpm lint
- pnpm build
- desktop and mobile browser QA on homepage, project archive, and Role Fit Brief

## Visual QA
- all 15 archive records render after expansion
- Astrocade preserves the dashboard title/context on mobile
- no horizontal overflow or browser console warnings/errors