### PR TITLE
Close site-wide release acceptance gaps

### DIFF
--- a/__tests__/global-route-context.test.ts
+++ b/__tests__/global-route-context.test.ts
@@ -55,4 +55,13 @@ describe("global route context", () => {
     expect(source).toContain('aria-label="Mobile navigation"')
     expect(source).toContain("setIsMobileMenuOpen(false)")
   })
+
+  it("keeps the contact conversion target clear of the sticky navigation", () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, "..", "app", "about", "page.tsx"),
+      "utf8"
+    )
+
+    expect(source).toContain('id="contact-title" className="scroll-mt-24"')
+  })
 })

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -304,7 +304,7 @@ export default function AboutPage() {
       <section className="profile-contact-section" aria-labelledby="contact-title">
         <div className="profile-contact-intro">
           <p className="operating-profile-eyebrow">Location and availability</p>
-          <h2 id="contact-title">Start with the system you need to make usable</h2>
+          <h2 id="contact-title" className="scroll-mt-24">Start with the system you need to make usable</h2>
           <p>
             Based in Pacifica, California. Focused on Bay Area and remote product, design engineering, and AI systems roles.
           </p>

--- a/components/role-fit-brief.tsx
+++ b/components/role-fit-brief.tsx
@@ -11,7 +11,7 @@ import type {
   AdaptiveFocusV2Result,
   ProjectMatch,
 } from "@/features/adaptive-focus"
-import { CAPABILITY_LABELS } from "@/features/adaptive-focus"
+import { CAPABILITY_LABELS, ROLE_FAMILY_LABELS } from "@/features/adaptive-focus"
 
 const PROJECTS_BY_ID = new Map(PROJECTS.map((project) => [project.id, project]))
 
@@ -119,7 +119,7 @@ export function RoleFitBrief({
         <dl className="grid gap-3 text-sm sm:grid-cols-3">
           <div>
             <dt className="text-xs uppercase text-muted-foreground">Role family</dt>
-            <dd className="mt-1 capitalize">{interpretation.roleFamily.replaceAll("-", " ")}</dd>
+            <dd className="mt-1">{ROLE_FAMILY_LABELS[interpretation.roleFamily]}</dd>
           </div>
           <div>
             <dt className="text-xs uppercase text-muted-foreground">Seniority</dt>

--- a/design-qa-release-acceptance.md
+++ b/design-qa-release-acceptance.md
@@ -1,0 +1,58 @@
+# Site-Wide Release Acceptance
+
+## Reference
+
+- Production site: `https://www.mikechaves.io`
+- Desktop viewport: 1440 x 900
+- Mobile viewport: 390 x 844
+- Captured evidence: `/tmp/portfolio-release-audit/01-home-desktop.png` through
+  `/tmp/portfolio-release-audit/11-contact-mobile.png`
+- Audit date: July 12, 2026
+
+## Journey
+
+1. Homepage positioning and Adaptive Focus entry
+2. Local preset handoff into a Role Fit Brief
+3. Primary Astrocade evidence dossier
+4. Related evidence, Role Fit Brief, resume, and contact exit paths
+5. About-page contact destination
+6. The same path at 390px mobile
+
+## Accepted Behavior
+
+- Homepage positioning, primary actions, Adaptive Focus lenses, and featured evidence are present in
+  the first desktop viewport.
+- The Human-in-the-loop AI preset initializes a deterministic Role Fit Brief without a model request.
+- Astrocade appears as primary proof with reviewed evidence, requirement coverage, and traceable case
+  study links.
+- Evidence dossiers expose related projects, a capability-preserving Role Fit Brief action, resume
+  access, and a direct contact path.
+- The contact destination includes availability, professional links, explicit form labels, required
+  fields, pending state, and status feedback.
+- Desktop and mobile checks produced no browser warnings or errors.
+- At 390px, audited routes had no horizontal overflow and the dossier remained readable through its
+  final conversion actions.
+
+## Release Fixes
+
+- Preserve acronym casing in Adaptive Focus summaries, explanations, gaps, and role-family labels.
+- Add scroll clearance so the mobile contact heading is not hidden beneath sticky navigation.
+- Remove the completed thumbnail-crop item from Future Backlog and record the completed dossier and
+  acceptance baseline in Active Backlog.
+
+## Evidence Limits
+
+- Screenshots support visual hierarchy, responsiveness, and route continuity; they do not establish
+  full WCAG conformance.
+- The audit did not submit the production contact form or send personal information.
+- External link syntax and local asset coverage remain part of the repository validation suite.
+
+## Validation
+
+- `pnpm test`
+- `pnpm lint`
+- `pnpm check:links`
+- `pnpm build`
+- Production browser QA on homepage, projects, Astrocade, and About/contact
+
+final result: passed

--- a/docs/backlog/ACTIVE_BACKLOG.md
+++ b/docs/backlog/ACTIVE_BACKLOG.md
@@ -2,7 +2,7 @@
 
 > Current execution queue for the portfolio site.
 
-_Current as of: 2026-07-09_
+_Current as of: 2026-07-12_
 
 ---
 
@@ -30,6 +30,10 @@ Rules:
   proof from Astrocade, Wizzo, X Games, Creative Supply Engine, Vulnerability Visualizer, and related
   work.
 - Wizzo is supporting product proof, not the primary identity.
+- All 15 public projects now use the shared evidence-dossier presentation, reviewed project media,
+  global route context, evidence-driven exit paths, and calibrated archive thumbnails.
+- The production hiring-manager journey has been accepted at desktop and 390px mobile from homepage
+  through Adaptive Focus, primary proof, related evidence, resume access, and contact.
 
 ## Priority Legend
 

--- a/docs/backlog/FUTURE_BACKLOG.md
+++ b/docs/backlog/FUTURE_BACKLOG.md
@@ -2,7 +2,7 @@
 
 > Deferred and long-range portfolio programs that are not in the active execution queue.
 
-_Current as of: 2026-05-25_
+_Current as of: 2026-07-12_
 
 ---
 
@@ -53,7 +53,6 @@ If another doc, review, critique, or conversation records a follow-up, it must a
 ## Design System And UI Polish
 
 - [ ] Add clearer active states for project filters if usage testing shows confusion.
-- [ ] Consider alternate thumbnails for projects whose primary image reads poorly in card crops.
 
 ## Strategic Framing
 

--- a/features/adaptive-focus/adaptive-focus.test.ts
+++ b/features/adaptive-focus/adaptive-focus.test.ts
@@ -1,5 +1,6 @@
 import {
   buildRoleFitBrief,
+  ROLE_FAMILY_LABELS,
   interpretLocalRole,
   normalizeRoleInput,
   type ProjectEvidence,
@@ -131,6 +132,16 @@ describe("Adaptive Focus Role Fit Brief", () => {
     const first = await localEngine.run({ mode: "preset", presetId: "hitl-evaluation" })
     const second = await localEngine.run({ mode: "preset", presetId: "hitl-evaluation" })
     expect(first).toEqual(second)
+  })
+
+  it("preserves AI, QA, UX, and XR casing in visitor-facing copy", async () => {
+    const hitl = await localEngine.run({ mode: "preset", presetId: "hitl-evaluation" })
+
+    expect(hitl.summary).toContain("human-in-the-loop AI")
+    expect(hitl.summary).toContain("moderation and QA")
+    expect(hitl.groups.primary[0].explanation).toContain("operational UX")
+    expect(ROLE_FAMILY_LABELS[hitl.interpretation.roleFamily]).toBe("AI product")
+    expect(ROLE_FAMILY_LABELS["xr-spatial"]).toBe("XR and spatial computing")
   })
 
   it("ranks direct evidence above supporting and adjacent evidence", () => {

--- a/features/adaptive-focus/index.ts
+++ b/features/adaptive-focus/index.ts
@@ -33,7 +33,10 @@ export function rebuildAdaptiveFocusBrief(
 
 export { ADAPTIVE_FOCUS_PRESETS }
 export { AI_PROJECT_IDS, PROJECT_EVIDENCE } from "./evidence/catalog"
-export { CAPABILITY_LABELS } from "../../packages/adaptive-focus-core/src"
+export {
+  CAPABILITY_LABELS,
+  ROLE_FAMILY_LABELS,
+} from "../../packages/adaptive-focus-core/src"
 export type {
   AdaptiveCapability,
   AdaptiveFocusAnalysisSource,

--- a/packages/adaptive-focus-core/src/copy.ts
+++ b/packages/adaptive-focus-core/src/copy.ts
@@ -1,0 +1,19 @@
+import type { RoleFamily } from "./types"
+
+export const ROLE_FAMILY_LABELS: Record<RoleFamily, string> = {
+  "ai-product": "AI product",
+  "design-engineering": "Design engineering",
+  "product-design": "Product design",
+  "product-engineering": "Product engineering",
+  "creative-technology": "Creative technology",
+  "xr-spatial": "XR and spatial computing",
+  operations: "Operations",
+  research: "Research",
+  leadership: "Leadership",
+  unknown: "Unknown",
+}
+
+export function formatLabelForSentence(label: string): string {
+  if (/^[A-Z]{2,}(?:\b|$)/u.test(label)) return label
+  return `${label.charAt(0).toLowerCase()}${label.slice(1)}`
+}

--- a/packages/adaptive-focus-core/src/index.ts
+++ b/packages/adaptive-focus-core/src/index.ts
@@ -1,5 +1,6 @@
 export { interpretLocalRole, normalizeRoleInput } from "./interpretation"
 export { buildRoleFitBrief, CAPABILITY_LABELS } from "./matching"
+export { formatLabelForSentence, ROLE_FAMILY_LABELS } from "./copy"
 export { createBriefSummary } from "./summary"
 export {
   ADAPTIVE_CAPABILITIES,

--- a/packages/adaptive-focus-core/src/matching.ts
+++ b/packages/adaptive-focus-core/src/matching.ts
@@ -1,4 +1,5 @@
 import { createBriefSummary } from "./summary"
+import { formatLabelForSentence } from "./copy"
 import type {
   AdaptiveCapability,
   AdaptiveFocusAnalysisSource,
@@ -159,7 +160,9 @@ export function buildRoleFitBrief(
         .slice(0, 3)
       const level = strongestConfidence === "direct" ? "primary" : strongestConfidence === "supporting" ? "supporting" : "adjacent"
       const levelCopy = level === "primary" ? "Primary proof" : level === "supporting" ? "Strong supporting proof" : "Adjacent experience"
-      const capabilityCopy = matchedCapabilities.map((capability) => CAPABILITY_LABELS[capability]).join(", ")
+      const capabilityCopy = matchedCapabilities
+        .map((capability) => formatLabelForSentence(CAPABILITY_LABELS[capability]))
+        .join(", ")
       const firstEvidence = selectedEvidence[0]
 
       return {
@@ -178,7 +181,7 @@ export function buildRoleFitBrief(
             sourceSection: item.sourceSection,
             outcome: item.outcome,
           })),
-          explanation: `${levelCopy} for ${capabilityCopy.toLowerCase()}. ${firstEvidence.statement}`,
+          explanation: `${levelCopy} for ${capabilityCopy}. ${firstEvidence.statement}`,
         } satisfies ProjectMatch,
       }
     })
@@ -216,7 +219,7 @@ export function buildRoleFitBrief(
     .map((item) => ({
       capability: item.capability,
       label: item.label,
-      reason: `No direct portfolio evidence is documented for ${item.label.toLowerCase()}.`,
+      reason: `No direct portfolio evidence is documented for ${formatLabelForSentence(item.label)}.`,
     }))
 
   return {

--- a/packages/adaptive-focus-core/src/summary.ts
+++ b/packages/adaptive-focus-core/src/summary.ts
@@ -1,4 +1,5 @@
 import type { CoverageGap, ProjectMatch, RequirementCoverage } from "./types"
+import { formatLabelForSentence } from "./copy"
 
 export function createBriefSummary(
   primary: ProjectMatch[],
@@ -7,7 +8,7 @@ export function createBriefSummary(
 ): string {
   const strongest = coverage
     .filter((item) => item.coverage === "strong")
-    .map((item) => item.label.toLowerCase())
+    .map((item) => formatLabelForSentence(item.label))
     .slice(0, 3)
 
   if (!primary.length && !strongest.length) {
@@ -20,7 +21,7 @@ export function createBriefSummary(
   const gapCopy = gaps.length
     ? ` No direct evidence is documented for ${gaps
         .slice(0, 2)
-        .map((gap) => gap.label.toLowerCase())
+        .map((gap) => formatLabelForSentence(gap.label))
         .join(" or ")}.`
     : ""
 


### PR DESCRIPTION
## Summary
- document the accepted homepage-to-contact hiring-manager journey across desktop and mobile
- preserve AI, QA, UX, and XR casing throughout Adaptive Focus visitor-facing copy
- keep the mobile contact anchor clear of the sticky navigation
- reconcile completed dossier and thumbnail work in the active/future backlogs

## Visual QA
- audited production at 1440x900 and 390x844
- compared production and implementation screenshots for both fixes
- verified the local Role Fit Brief and contact destination after the production build

## Validation
- pnpm test (154 tests)
- pnpm lint
- pnpm check:links
- pnpm build