### PR TITLE
Add privacy-safe portfolio conversion analytics

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -14,6 +14,7 @@ import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { PROJECTS } from "@/data/projects"
 import { useToast } from "@/hooks/use-toast"
+import { trackPortfolioEvent } from "@/lib/portfolio-analytics"
 import "@fortawesome/fontawesome-svg-core/styles.css"
 import { config } from "@fortawesome/fontawesome-svg-core"
 
@@ -49,6 +50,7 @@ const proofPoints = [
     label: "Human-in-the-loop AI / Evaluation",
     description: "Owned UGC review systems spanning QA annotation, calibration, final review behavior, creator feedback, and operational guardrails.",
     href: "/projects/astrocade-qa-calibration-tool",
+    projectId: "astrocade-qa-calibration-tool",
   },
   {
     caseFile: "AF-02",
@@ -56,6 +58,7 @@ const proofPoints = [
     label: "AI product systems / Intent to action",
     description: "Designed and built an AI mentor product system connecting chat, work context, goals, and follow-up to actionable quests.",
     href: "/projects/wizzo",
+    projectId: "wizzo",
   },
   {
     caseFile: "XR-01",
@@ -63,6 +66,7 @@ const proofPoints = [
     label: "Voice interaction / Accessibility",
     description: "Designed a voice-controlled mixed reality system for users with low muscle tone, grounding emerging interaction in access needs.",
     href: "/projects/speakeasy",
+    projectId: "speakeasy",
   },
   {
     caseFile: "OPS-01",
@@ -70,6 +74,7 @@ const proofPoints = [
     label: "Operational UX / Spatial tools",
     description: "Built enterprise internal tools, spatial operations prototypes, and WebGL systems for Starbucks, Ford, and POWER Engineers.",
     href: "/projects?focusPreset=operational-ux",
+    projectId: null,
   },
 ]
 
@@ -146,6 +151,7 @@ export default function AboutPage() {
         setFormStatus({ success: response.success, message: response.message })
 
         if (response.success) {
+          trackPortfolioEvent("portfolio_contact_submitted", { source: "about_form" })
           form.reset()
           toast({ title: "Message sent", description: response.message })
         } else {
@@ -187,7 +193,17 @@ export default function AboutPage() {
               <Link href="/projects" className="operating-profile-primary-action">
                 Inspect project proof <ArrowRight size={15} aria-hidden="true" />
               </Link>
-              <a href="/Michael_Chaves_Resume_min.pdf" download className="operating-profile-secondary-action">
+              <a
+                href="/Michael_Chaves_Resume_min.pdf"
+                download
+                onClick={() =>
+                  trackPortfolioEvent("portfolio_conversion_clicked", {
+                    destination: "resume",
+                    source: "about_hero",
+                  })
+                }
+                className="operating-profile-secondary-action"
+              >
                 Download resume <Download size={15} aria-hidden="true" />
               </a>
             </div>
@@ -246,7 +262,25 @@ export default function AboutPage() {
         </div>
         <div className="profile-proof-grid">
           {proofPoints.map((proof) => (
-            <Link key={proof.caseFile} href={proof.href} className="profile-proof-record">
+            <Link
+              key={proof.caseFile}
+              href={proof.href}
+              onClick={() => {
+                if (proof.projectId) {
+                  trackPortfolioEvent("project_evidence_opened", {
+                    project_id: proof.projectId,
+                    source: "about_proof",
+                    match_level: "unranked",
+                  })
+                  return
+                }
+                trackPortfolioEvent("portfolio_conversion_clicked", {
+                  destination: "role_fit",
+                  source: "about_proof",
+                })
+              }}
+              className="profile-proof-record"
+            >
               <div className="profile-proof-meta">
                 <span>{proof.caseFile}</span>
                 <span>{proof.label}</span>
@@ -308,7 +342,17 @@ export default function AboutPage() {
           <p>
             Based in Pacifica, California. Focused on Bay Area and remote product, design engineering, and AI systems roles.
           </p>
-          <a href="/Michael_Chaves_Resume_min.pdf" download className="operating-profile-secondary-action">
+          <a
+            href="/Michael_Chaves_Resume_min.pdf"
+            download
+            onClick={() =>
+              trackPortfolioEvent("portfolio_conversion_clicked", {
+                destination: "resume",
+                source: "about_contact",
+              })
+            }
+            className="operating-profile-secondary-action"
+          >
             Download resume <Download size={15} aria-hidden="true" />
           </a>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -111,7 +111,12 @@ export default function Home() {
 
           <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
             {featuredProjects.map((project, index) => (
-              <ProjectCard key={project.id} {...project} priority={index < 3} />
+              <ProjectCard
+                key={project.id}
+                {...project}
+                analyticsContext="home_featured"
+                priority={index < 3}
+              />
             ))}
           </div>
         </section>

--- a/app/projects/[id]/DossierExitPath.tsx
+++ b/app/projects/[id]/DossierExitPath.tsx
@@ -2,13 +2,16 @@
 
 import Link from "next/link"
 import { ArrowRight, Download, FileSearch2, MessageSquareText } from "lucide-react"
+import { trackPortfolioEvent } from "@/lib/portfolio-analytics"
 import type { DossierExitPath as DossierExitPathData } from "./dossierExitPathData"
 
 export function DossierExitPath({
   exitPath,
+  projectId,
   projectTitle,
 }: {
   exitPath: DossierExitPathData
+  projectId: string
   projectTitle: string
 }) {
   return (
@@ -37,7 +40,17 @@ export function DossierExitPath({
         <div className="dossier-related-evidence" aria-label="Related project evidence">
           <p>Related evidence</p>
           {exitPath.relatedProjects.map((related, index) => (
-            <Link key={related.projectId} href={`/projects/${related.projectId}`}>
+            <Link
+              key={related.projectId}
+              href={`/projects/${related.projectId}`}
+              onClick={() =>
+                trackPortfolioEvent("project_evidence_opened", {
+                  project_id: related.projectId,
+                  source: "dossier_related",
+                  match_level: "supporting",
+                })
+              }
+            >
               <span className="dossier-related-index">0{index + 1}</span>
               <span>
                 <strong>{related.title}</strong>
@@ -53,7 +66,17 @@ export function DossierExitPath({
         </div>
 
         <div className="dossier-exit-actions" aria-label="Role fit and contact actions">
-          <Link href={exitPath.focusHref} className="dossier-exit-primary-action">
+          <Link
+            href={exitPath.focusHref}
+            onClick={() =>
+              trackPortfolioEvent("portfolio_conversion_clicked", {
+                destination: "role_fit",
+                source: "dossier_exit",
+                project_id: projectId,
+              })
+            }
+            className="dossier-exit-primary-action"
+          >
             <FileSearch2 size={17} aria-hidden="true" />
             <span>
               <strong>Build Role Fit Brief</strong>
@@ -61,11 +84,30 @@ export function DossierExitPath({
             </span>
             <ArrowRight size={16} aria-hidden="true" />
           </Link>
-          <Link href="/about#contact-title">
+          <Link
+            href="/about#contact-title"
+            onClick={() =>
+              trackPortfolioEvent("portfolio_conversion_clicked", {
+                destination: "contact",
+                source: "dossier_exit",
+                project_id: projectId,
+              })
+            }
+          >
             <MessageSquareText size={17} aria-hidden="true" />
             Start a conversation
           </Link>
-          <a href="/Michael_Chaves_Resume_min.pdf" download>
+          <a
+            href="/Michael_Chaves_Resume_min.pdf"
+            download
+            onClick={() =>
+              trackPortfolioEvent("portfolio_conversion_clicked", {
+                destination: "resume",
+                source: "dossier_exit",
+                project_id: projectId,
+              })
+            }
+          >
             <Download size={17} aria-hidden="true" />
             Download resume
           </a>

--- a/app/projects/[id]/ProjectPageClient.tsx
+++ b/app/projects/[id]/ProjectPageClient.tsx
@@ -400,7 +400,11 @@ export default function ProjectPageClient({ dossierExitPath, project }: ProjectP
         </div>
       </div>
       {isEvidenceDossier && (
-        <DossierExitPath exitPath={dossierExitPath} projectTitle={project.title} />
+        <DossierExitPath
+          exitPath={dossierExitPath}
+          projectId={project.id}
+          projectTitle={project.title}
+        />
       )}
       <ImageModal
         open={selectedIndex !== null}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -24,6 +24,11 @@ import {
   resolveAdaptiveFocusInitialization,
 } from "@/features/adaptive-focus/handoff"
 import { useAdaptiveFocusHandoff } from "@/features/adaptive-focus/handoff-context"
+import {
+  trackPortfolioEvent,
+  type AdaptiveFocusEntryPoint,
+  type ProjectMatchLevel,
+} from "@/lib/portfolio-analytics"
 import type { Project } from "@/types/project"
 import { EVIDENCE_DOSSIER_PROJECT_IDS } from "./[id]/dossierConfig"
 
@@ -87,6 +92,14 @@ export default function ProjectsPage() {
   )
 
   const visibleProjects = display.slice(0, showAll ? display.length : initialLimit)
+  const briefMatchLevels = useMemo(() => {
+    const levels = new Map<string, ProjectMatchLevel>()
+    if (!brief) return levels
+    for (const group of [brief.groups.primary, brief.groups.supporting, brief.groups.adjacent]) {
+      for (const match of group) levels.set(match.projectId, match.level)
+    }
+    return levels
+  }, [brief])
 
   const applyBrief = useCallback((result: AdaptiveFocusV2Result) => {
     setBrief(result)
@@ -96,12 +109,24 @@ export default function ProjectsPage() {
   }, [])
 
   const executeRequest = useCallback(
-    async (request: AdaptiveFocusRequest, moveFocus = true) => {
+    async (
+      request: AdaptiveFocusRequest,
+      moveFocus = true,
+      entryPoint: AdaptiveFocusEntryPoint = "projects"
+    ) => {
       abortRef.current?.abort()
       const controller = new AbortController()
       abortRef.current = controller
       setRequestState("loading")
       setStatusMessage("Mapping role requirements to reviewed portfolio evidence...")
+
+      const analyticsMode = request.mode === "interpretation" ? null : request.mode
+      if (analyticsMode && entryPoint === "projects") {
+        trackPortfolioEvent("adaptive_focus_started", {
+          entry_point: entryPoint,
+          mode: analyticsMode,
+        })
+      }
 
       if (request.mode === "custom") setQuery(request.input)
       if (request.mode === "preset") {
@@ -112,6 +137,16 @@ export default function ProjectsPage() {
       try {
         const result = await runAdaptiveFocus(request, { signal: controller.signal })
         if (controller.signal.aborted) return
+        if (analyticsMode) {
+          trackPortfolioEvent("adaptive_focus_completed", {
+            entry_point: entryPoint,
+            mode: analyticsMode,
+            analysis_source: result.analysisSource,
+            clarification_needed: result.interpretation.clarificationNeeded,
+            requirement_count: result.interpretation.requirements.length,
+            primary_project_count: result.groups.primary.length,
+          })
+        }
         applyBrief(result)
         setRequestState("idle")
         setStatusMessage(
@@ -126,6 +161,12 @@ export default function ProjectsPage() {
         }
       } catch (error) {
         if (controller.signal.aborted || (error instanceof DOMException && error.name === "AbortError")) return
+        if (analyticsMode) {
+          trackPortfolioEvent("adaptive_focus_failed", {
+            entry_point: entryPoint,
+            mode: analyticsMode,
+          })
+        }
         setRequestState("error")
         setStatusMessage("Adaptive Focus could not complete this request. Try again or use a preset lens.")
       }
@@ -170,7 +211,7 @@ export default function ProjectsPage() {
           ? ({ mode: "custom", input: pendingInput } as const)
           : resolveAdaptiveFocusInitialization(window.location.search, window.sessionStorage)
       if (request) {
-        void executeRequest(request)
+        void executeRequest(request, true, "handoff")
       } else if (params.get("focusSession") === "1") {
         setRequestState("error")
         setStatusMessage("The temporary role request expired. Paste the role text again to continue.")
@@ -401,6 +442,8 @@ export default function ProjectsPage() {
                 technologies={project.technologies}
                 category={project.category}
                 thumbnailFocalPoint={project.thumbnailFocalPoint}
+                analyticsContext={brief ? "role_fit_archive" : "project_archive"}
+                analyticsMatchLevel={briefMatchLevels.get(project.id) ?? "unranked"}
                 priority={index === 0}
               />
             </div>

--- a/components/adaptive-focus-entry.tsx
+++ b/components/adaptive-focus-entry.tsx
@@ -20,6 +20,7 @@ import {
   encodeAdaptiveFocusBriefHandoff,
 } from "@/features/adaptive-focus/handoff"
 import { useAdaptiveFocusHandoff } from "@/features/adaptive-focus/handoff-context"
+import { trackPortfolioEvent } from "@/lib/portfolio-analytics"
 
 export function AdaptiveFocusEntry() {
   const router = useRouter()
@@ -34,12 +35,28 @@ export function AdaptiveFocusEntry() {
     event.preventDefault()
     setError("")
     setIsLoading(true)
+    trackPortfolioEvent("adaptive_focus_started", {
+      entry_point: "home",
+      mode: "custom",
+    })
     try {
       preparePendingInput(input)
       const result = await runAdaptiveFocus({ mode: "custom", input: input.trim() })
+      trackPortfolioEvent("adaptive_focus_completed", {
+        entry_point: "home",
+        mode: "custom",
+        analysis_source: result.analysisSource,
+        clarification_needed: result.interpretation.clarificationNeeded,
+        requirement_count: result.interpretation.requirements.length,
+        primary_project_count: result.groups.primary.length,
+      })
       const briefToken = encodeAdaptiveFocusBriefHandoff(result)
       router.push(`/projects?focusBrief=${briefToken}&focusSession=1`)
     } catch {
+      trackPortfolioEvent("adaptive_focus_failed", {
+        entry_point: "home",
+        mode: "custom",
+      })
       setError(
         "Adaptive Focus could not prepare this brief. Try again or open Projects and use a preset lens."
       )
@@ -89,7 +106,13 @@ export function AdaptiveFocusEntry() {
                     key={preset.id}
                     type="button"
                     disabled={isLoading}
-                    onClick={() => router.push(`/projects?focusPreset=${preset.id}`)}
+                    onClick={() => {
+                      trackPortfolioEvent("adaptive_focus_started", {
+                        entry_point: "home",
+                        mode: "preset",
+                      })
+                      router.push(`/projects?focusPreset=${preset.id}`)
+                    }}
                     className="group min-h-16 bg-black px-3 py-2 text-left transition-colors hover:bg-primary/[0.07] focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     <span className="flex items-center gap-2 text-xs font-semibold text-zinc-200 group-hover:text-primary">

--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -1,9 +1,18 @@
+"use client"
+
 import Image from "next/image"
 import Link from "next/link"
 import { ArrowUpRight } from "lucide-react"
+import {
+  trackPortfolioEvent,
+  type ProjectEvidenceSource,
+  type ProjectMatchLevel,
+} from "@/lib/portfolio-analytics"
 import type { Project, ProjectThumbnailFocalPoint } from "@/types/project"
 
 type ProjectCardProps = Project & {
+  analyticsContext?: ProjectEvidenceSource
+  analyticsMatchLevel?: ProjectMatchLevel
   priority?: boolean
 }
 
@@ -22,11 +31,23 @@ export function ProjectCard({
   image,
   technologies,
   thumbnailFocalPoint = "center",
+  analyticsContext,
+  analyticsMatchLevel = "unranked",
   priority,
 }: ProjectCardProps) {
   return (
     <Link
       href={`/projects/${id}`}
+      onClick={
+        analyticsContext
+          ? () =>
+              trackPortfolioEvent("project_evidence_opened", {
+                project_id: id,
+                source: analyticsContext,
+                match_level: analyticsMatchLevel,
+              })
+          : undefined
+      }
       className="group block h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     >
       <article className="signal-project-card h-full overflow-hidden border border-white/15 bg-black/80 transition-colors group-hover:border-primary/60">

--- a/components/role-fit-brief.tsx
+++ b/components/role-fit-brief.tsx
@@ -12,6 +12,7 @@ import type {
   ProjectMatch,
 } from "@/features/adaptive-focus"
 import { CAPABILITY_LABELS, ROLE_FAMILY_LABELS } from "@/features/adaptive-focus"
+import { trackPortfolioEvent } from "@/lib/portfolio-analytics"
 
 const PROJECTS_BY_ID = new Map(PROJECTS.map((project) => [project.id, project]))
 
@@ -41,6 +42,8 @@ function ProjectProof({ match, priority = false }: { match: ProjectMatch; priori
         technologies={project.technologies}
         category={project.category}
         thumbnailFocalPoint={project.thumbnailFocalPoint}
+        analyticsContext="role_fit_primary"
+        analyticsMatchLevel={match.level}
         priority={priority}
       />
       <div className="space-y-4 py-1">
@@ -69,7 +72,17 @@ function ProjectProof({ match, priority = false }: { match: ProjectMatch; priori
             </li>
           ))}
         </ul>
-        <Link href={`/projects/${project.id}`} className="inline-flex items-center gap-1 text-sm text-primary hover:underline">
+        <Link
+          href={`/projects/${project.id}`}
+          onClick={() =>
+            trackPortfolioEvent("project_evidence_opened", {
+              project_id: project.id,
+              source: "role_fit_primary",
+              match_level: match.level,
+            })
+          }
+          className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+        >
           Inspect case study <ExternalLink size={14} aria-hidden="true" />
         </Link>
       </div>
@@ -178,7 +191,17 @@ export function RoleFitBrief({
               if (!project) return null
               return (
                 <div key={match.projectId} className="grid gap-2 py-4 sm:grid-cols-[12rem_1fr_auto] sm:items-center">
-                  <Link href={`/projects/${project.id}`} className="font-semibold text-primary hover:underline">
+                  <Link
+                    href={`/projects/${project.id}`}
+                    onClick={() =>
+                      trackPortfolioEvent("project_evidence_opened", {
+                        project_id: project.id,
+                        source: "role_fit_supporting",
+                        match_level: match.level,
+                      })
+                    }
+                    className="font-semibold text-primary hover:underline"
+                  >
                     {project.title}
                   </Link>
                   <p className="text-sm text-muted-foreground">{match.evidence[0]?.statement}</p>
@@ -240,7 +263,18 @@ export function RoleFitBrief({
             {brief.groups.adjacent.slice(0, 6).map((match) => {
               const project = PROJECTS_BY_ID.get(match.projectId)
               return project ? (
-                <Link key={project.id} href={`/projects/${project.id}`} className="text-muted-foreground hover:text-primary hover:underline">
+                <Link
+                  key={project.id}
+                  href={`/projects/${project.id}`}
+                  onClick={() =>
+                    trackPortfolioEvent("project_evidence_opened", {
+                      project_id: project.id,
+                      source: "role_fit_adjacent",
+                      match_level: match.level,
+                    })
+                  }
+                  className="text-muted-foreground hover:text-primary hover:underline"
+                >
                   {project.title}
                 </Link>
               ) : null

--- a/docs/analytics/PORTFOLIO_CONVERSION_ANALYTICS.md
+++ b/docs/analytics/PORTFOLIO_CONVERSION_ANALYTICS.md
@@ -1,0 +1,58 @@
+# Portfolio Conversion Analytics
+
+_Decision date: July 12, 2026_
+
+## Decision
+
+Use the existing Vercel Web Analytics integration for a small custom-event funnel. Do not add a
+second analytics provider, session replay, identity tracking, or raw role-text capture.
+
+The goal is to learn whether Adaptive Focus and reviewed project evidence help visitors reach a
+case study, resume, contact action, or successful contact submission. Pageviews remain the general
+traffic baseline; custom events answer only these product questions.
+
+## Event Contract
+
+| Event | Purpose | Allowed properties |
+| --- | --- | --- |
+| `adaptive_focus_started` | A visitor invoked a preset or custom role analysis. | `entry_point`, `mode` |
+| `adaptive_focus_completed` | A Role Fit Brief completed. | `entry_point`, `mode`, `analysis_source`, `clarification_needed`, `requirement_count`, `primary_project_count` |
+| `adaptive_focus_failed` | A requested analysis could not complete. | `entry_point`, `mode` |
+| `project_evidence_opened` | A visitor opened project evidence from a measured surface. | `project_id`, `source`, `match_level` |
+| `portfolio_conversion_clicked` | A visitor selected Role Fit, contact, or resume from a conversion surface. | `destination`, `source`, optional `project_id` |
+| `portfolio_contact_submitted` | The contact action returned a successful response. | `source` |
+
+## Privacy Posture
+
+The analytics wrapper uses a runtime property allowlist. Fields outside the event contract are
+dropped before the provider is called.
+
+Do not send:
+
+- custom role text or job descriptions
+- normalized queries or model output
+- names, email addresses, messages, or company names
+- contact-form contents
+- IP-derived identity or cross-site identifiers added by this application
+
+Project IDs, predefined source labels, result counts, booleans, and engine-source labels are public
+or bounded operational metadata. Vercel remains responsible for its platform-level data handling;
+this repository does not add analytics persistence.
+
+## Reliability
+
+Analytics is non-blocking. Provider failures are caught and must not interrupt navigation, Adaptive
+Focus, downloads, or contact submission. Tests verify the property allowlist and failure isolation.
+
+## Evaluation Gate
+
+Do not redesign the portfolio from a handful of events. Review the funnel after at least 30 days or
+100 qualified visits, whichever is later. Use the results to answer:
+
+1. Do visitors start and complete Adaptive Focus?
+2. Do Role Fit Briefs lead to primary evidence more often than the default archive?
+3. Which proof surfaces lead to resume or contact actions?
+4. Are fallback or clarification states common enough to justify parser or UI work?
+
+Low volume, bot traffic, and repeat visits limit attribution. Event counts indicate behavior, not
+hiring intent or causality.

--- a/docs/backlog/ACTIVE_BACKLOG.md
+++ b/docs/backlog/ACTIVE_BACKLOG.md
@@ -34,6 +34,8 @@ Rules:
   global route context, evidence-driven exit paths, and calibrated archive thumbnails.
 - The production hiring-manager journey has been accepted at desktop and 390px mobile from homepage
   through Adaptive Focus, primary proof, related evidence, resume access, and contact.
+- Privacy-safe Vercel custom events now measure the Adaptive Focus-to-evidence-to-conversion funnel
+  without sending raw role text or contact-form contents.
 
 ## Priority Legend
 
@@ -44,9 +46,9 @@ Rules:
 
 ## Active Workboard
 
-| Priority | Area                  | Item                                                                 | Status   | Validation / Exit Criteria                                                                                                                                             |
-| -------- | --------------------- | -------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| P2       | Portfolio Analytics   | Decide whether lightweight analytics should track project CTA and adaptive-focus usage. | RESEARCH | Decision note documents provider, privacy posture, tracked events, and whether analytics meaningfully improves portfolio iteration.                                    |
+No implementation item is active. Collect the analytics baseline defined in
+[Portfolio Conversion Analytics](../analytics/PORTFOLIO_CONVERSION_ANALYTICS.md) before promoting
+another UI or conversion change into this queue.
 
 ## Deferred
 

--- a/docs/backlog/FUTURE_BACKLOG.md
+++ b/docs/backlog/FUTURE_BACKLOG.md
@@ -47,7 +47,7 @@ If another doc, review, critique, or conversation records a follow-up, it must a
 ## Engineering And Operations
 
 - [ ] Add automated screenshot smoke tests for homepage, projects index, and top case studies.
-- [ ] Evaluate privacy-preserving analytics for CTA clicks, adaptive-focus searches, and project visits.
+- [ ] Review the privacy-safe conversion funnel after 30 days or 100 qualified visits, whichever is later.
 - [ ] Add a release checklist for production deploys, domains, and DNS checks.
 
 ## Design System And UI Polish

--- a/lib/__tests__/portfolio-analytics.test.ts
+++ b/lib/__tests__/portfolio-analytics.test.ts
@@ -1,0 +1,74 @@
+import { track } from "@vercel/analytics"
+import {
+  buildPortfolioAnalyticsProperties,
+  PORTFOLIO_ANALYTICS_PROPERTY_ALLOWLIST,
+  trackPortfolioEvent,
+  type PortfolioAnalyticsEventMap,
+} from "@/lib/portfolio-analytics"
+
+jest.mock("@vercel/analytics", () => ({
+  track: jest.fn(),
+}))
+
+const mockedTrack = jest.mocked(track)
+
+describe("portfolio analytics", () => {
+  beforeEach(() => {
+    mockedTrack.mockReset()
+  })
+
+  it("sends only the properties allowed for an event", () => {
+    const properties = {
+      entry_point: "home",
+      mode: "custom",
+      input: "confidential role text",
+      email: "visitor@example.com",
+    } as PortfolioAnalyticsEventMap["adaptive_focus_started"]
+
+    expect(buildPortfolioAnalyticsProperties("adaptive_focus_started", properties)).toEqual({
+      entry_point: "home",
+      mode: "custom",
+    })
+  })
+
+  it("tracks a bounded completion summary without visitor text", () => {
+    trackPortfolioEvent("adaptive_focus_completed", {
+      entry_point: "projects",
+      mode: "custom",
+      analysis_source: "gpt",
+      clarification_needed: false,
+      requirement_count: 4,
+      primary_project_count: 3,
+    })
+
+    expect(mockedTrack).toHaveBeenCalledWith("adaptive_focus_completed", {
+      entry_point: "projects",
+      mode: "custom",
+      analysis_source: "gpt",
+      clarification_needed: false,
+      requirement_count: 4,
+      primary_project_count: 3,
+    })
+  })
+
+  it("keeps analytics failures out of user workflows", () => {
+    mockedTrack.mockImplementationOnce(() => {
+      throw new Error("analytics unavailable")
+    })
+
+    expect(() =>
+      trackPortfolioEvent("portfolio_conversion_clicked", {
+        destination: "contact",
+        source: "dossier_exit",
+        project_id: "astrocade-qa-calibration-tool",
+      })
+    ).not.toThrow()
+  })
+
+  it("does not allow raw visitor-data fields in any event contract", () => {
+    const forbiddenProperty = /input|query|text|description|message|email|company|role_title/i
+    const propertyNames = Object.values(PORTFOLIO_ANALYTICS_PROPERTY_ALLOWLIST).flat()
+
+    expect(propertyNames).not.toEqual(expect.arrayContaining([expect.stringMatching(forbiddenProperty)]))
+  })
+})

--- a/lib/portfolio-analytics.ts
+++ b/lib/portfolio-analytics.ts
@@ -1,0 +1,99 @@
+import { track } from "@vercel/analytics"
+
+export type AdaptiveFocusEntryPoint = "home" | "projects" | "handoff"
+export type AdaptiveFocusMode = "preset" | "custom"
+export type ProjectEvidenceSource =
+  | "home_featured"
+  | "project_archive"
+  | "role_fit_primary"
+  | "role_fit_supporting"
+  | "role_fit_adjacent"
+  | "role_fit_archive"
+  | "dossier_related"
+  | "about_proof"
+export type ProjectMatchLevel = "primary" | "supporting" | "adjacent" | "unranked"
+export type PortfolioConversionSource =
+  | "about_hero"
+  | "about_contact"
+  | "about_proof"
+  | "dossier_exit"
+
+export interface PortfolioAnalyticsEventMap {
+  adaptive_focus_started: {
+    entry_point: AdaptiveFocusEntryPoint
+    mode: AdaptiveFocusMode
+  }
+  adaptive_focus_completed: {
+    entry_point: AdaptiveFocusEntryPoint
+    mode: AdaptiveFocusMode
+    analysis_source: "preset" | "gpt" | "local-fallback"
+    clarification_needed: boolean
+    requirement_count: number
+    primary_project_count: number
+  }
+  adaptive_focus_failed: {
+    entry_point: AdaptiveFocusEntryPoint
+    mode: AdaptiveFocusMode
+  }
+  project_evidence_opened: {
+    project_id: string
+    source: ProjectEvidenceSource
+    match_level: ProjectMatchLevel
+  }
+  portfolio_conversion_clicked: {
+    destination: "role_fit" | "contact" | "resume"
+    source: PortfolioConversionSource
+    project_id?: string
+  }
+  portfolio_contact_submitted: {
+    source: "about_form"
+  }
+}
+
+export type PortfolioAnalyticsEventName = keyof PortfolioAnalyticsEventMap
+type AllowedPropertyValue = string | number | boolean | null | undefined
+
+export const PORTFOLIO_ANALYTICS_PROPERTY_ALLOWLIST = {
+  adaptive_focus_started: ["entry_point", "mode"],
+  adaptive_focus_completed: [
+    "entry_point",
+    "mode",
+    "analysis_source",
+    "clarification_needed",
+    "requirement_count",
+    "primary_project_count",
+  ],
+  adaptive_focus_failed: ["entry_point", "mode"],
+  project_evidence_opened: ["project_id", "source", "match_level"],
+  portfolio_conversion_clicked: ["destination", "source", "project_id"],
+  portfolio_contact_submitted: ["source"],
+} as const satisfies {
+  [Name in PortfolioAnalyticsEventName]: readonly (keyof PortfolioAnalyticsEventMap[Name])[]
+}
+
+export function buildPortfolioAnalyticsProperties<Name extends PortfolioAnalyticsEventName>(
+  name: Name,
+  properties: PortfolioAnalyticsEventMap[Name]
+): Record<string, AllowedPropertyValue> {
+  const allowedKeys = PORTFOLIO_ANALYTICS_PROPERTY_ALLOWLIST[name]
+  const source = properties as Record<string, AllowedPropertyValue>
+  const safeProperties: Record<string, AllowedPropertyValue> = {}
+
+  for (const key of allowedKeys) {
+    const value = source[key]
+    if (value !== undefined) safeProperties[key] = value
+  }
+
+  return safeProperties
+}
+
+export function trackPortfolioEvent<Name extends PortfolioAnalyticsEventName>(
+  name: Name,
+  properties: PortfolioAnalyticsEventMap[Name]
+): void {
+  try {
+    track(name, buildPortfolioAnalyticsProperties(name, properties))
+  } catch {
+    // Analytics must never interrupt portfolio navigation or conversion flows.
+  }
+}


### PR DESCRIPTION
## Summary
- add a typed Vercel Analytics event contract with a runtime property allowlist
- measure Adaptive Focus starts/completions/failures, evidence opens, resume/contact/Role Fit exits, and successful contact submission
- omit raw role text, model output, company context, and all contact-form contents
- keep analytics failures non-blocking
- document the decision and move the completed research item out of the active backlog

## Privacy
- no new analytics provider or persistence
- no job descriptions, queries, names, emails, or messages in event properties
- allowlist tests drop accidental extra fields before the provider call

## Validation
- pnpm test (158 tests)
- pnpm lint
- pnpm check:links
- pnpm build
- local browser QA: Role Fit Brief, Astrocade dossier exits, About/contact