### PR TITLE
Add automated portfolio screenshot smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,35 @@ jobs:
       - run: pnpm lint
       - run: pnpm test
       - run: pnpm check:links
+
+  visual-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Determine Node version
+        id: node
+        run: |
+          if [ -f .nvmrc ]; then
+            echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$(node -e 'const p=require("./package.json"); console.log(p.engines?.node || "20");')" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ steps.node.outputs.version }}
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm test:visual-smoke
+      - name: Upload rendered route screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: portfolio-visual-smoke
+          path: test-results/playwright/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ yarn-error.log*
 # vercel
 .vercel
 
+# playwright
+/playwright-report/
+/test-results/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ pnpm install
 pnpm dev
 pnpm build
 pnpm lint
+pnpm test
 ```
 
 The project uses ESLint with Next.js's strict configuration. Run `pnpm lint` to check for warnings in the codebase.
@@ -18,6 +19,17 @@ The project uses ESLint with Next.js's strict configuration. Run `pnpm lint` to 
 The local site will be running at [http://localhost:3000](http://localhost:3000).
 
 The production site is available at [https://mikechaves.io](https://mikechaves.io).
+
+### Visual Smoke Tests
+
+Install Chromium once, then run the desktop and mobile route checks:
+
+```bash
+pnpm exec playwright install chromium
+pnpm test:visual-smoke
+```
+
+The suite validates the homepage, project archive, representative evidence dossiers, and the project-category interaction. CI uploads the full-page screenshots as the `portfolio-visual-smoke` artifact for 14 days.
 
 ### Environment Variables
 

--- a/docs/backlog/ACTIVE_BACKLOG.md
+++ b/docs/backlog/ACTIVE_BACKLOG.md
@@ -36,6 +36,8 @@ Rules:
   through Adaptive Focus, primary proof, related evidence, resume access, and contact.
 - Privacy-safe Vercel custom events now measure the Adaptive Focus-to-evidence-to-conversion funnel
   without sending raw role text or contact-form contents.
+- CI now captures desktop and 390px mobile smoke evidence for the homepage, project archive, and
+  representative case studies, including a live project-filter interaction.
 
 ## Priority Legend
 

--- a/docs/backlog/FUTURE_BACKLOG.md
+++ b/docs/backlog/FUTURE_BACKLOG.md
@@ -46,7 +46,6 @@ If another doc, review, critique, or conversation records a follow-up, it must a
 
 ## Engineering And Operations
 
-- [ ] Add automated screenshot smoke tests for homepage, projects index, and top case studies.
 - [ ] Review the privacy-safe conversion funnel after 30 days or 100 qualified visits, whichever is later.
 - [ ] Add a release checklist for production deploys, domains, and DNS checks.
 

--- a/e2e/route-visual-smoke.spec.ts
+++ b/e2e/route-visual-smoke.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test, type Page, type TestInfo } from "@playwright/test"
+
+interface SmokeRoute {
+  name: string
+  path: string
+  heading: string | RegExp
+}
+
+const routes: SmokeRoute[] = [
+  { name: "home", path: "/", heading: /^Mike_\s*Chaves_$/i },
+  { name: "projects", path: "/projects", heading: "Project Signal Index" },
+  {
+    name: "astrocade",
+    path: "/projects/astrocade-qa-calibration-tool",
+    heading: "Astrocade AI QA Calibration Tool",
+  },
+  { name: "wizzo", path: "/projects/wizzo", heading: "Wizzo" },
+  { name: "speakeasy", path: "/projects/speakeasy", heading: "SpeakEasy" },
+]
+
+async function settleVisuals(page: Page) {
+  await page.emulateMedia({ reducedMotion: "reduce", colorScheme: "dark" })
+  await page.addStyleTag({
+    content: `
+      *, *::before, *::after {
+        animation-delay: 0s !important;
+        animation-duration: 0s !important;
+        caret-color: transparent !important;
+        transition-delay: 0s !important;
+        transition-duration: 0s !important;
+      }
+    `,
+  })
+  await page.evaluate(async () => {
+    await document.fonts.ready
+    const step = Math.max(window.innerHeight * 0.8, 400)
+    for (let y = 0; y < document.documentElement.scrollHeight; y += step) {
+      window.scrollTo(0, y)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    }
+    window.scrollTo(0, 0)
+  })
+  await page.waitForTimeout(100)
+}
+
+async function captureRoute(page: Page, testInfo: TestInfo, route: SmokeRoute) {
+  const pageErrors: string[] = []
+  const consoleErrors: string[] = []
+  page.on("pageerror", (error) => pageErrors.push(error.message))
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text())
+  })
+
+  const response = await page.goto(route.path, { waitUntil: "domcontentloaded" })
+
+  expect(response?.ok(), `${route.path} should return a successful response`).toBe(true)
+  await expect(page.getByRole("heading", { level: 1, name: route.heading })).toBeVisible()
+  await expect(page.locator("body")).not.toContainText("Internal Server Error")
+  await expect(page.locator("nextjs-portal [data-nextjs-dialog-overlay]")).toHaveCount(0)
+  await settleVisuals(page)
+  expect(pageErrors, `${route.path} should not raise browser runtime errors`).toEqual([])
+  expect(consoleErrors, `${route.path} should not log browser console errors`).toEqual([])
+
+  const screenshotPath = testInfo.outputPath(`${route.name}-full-page.png`)
+  await page.screenshot({
+    path: screenshotPath,
+    fullPage: true,
+    animations: "disabled",
+  })
+}
+
+for (const route of routes) {
+  test(`${route.name} renders without a framework or runtime failure`, async ({ page }, testInfo) => {
+    await captureRoute(page, testInfo, route)
+  })
+}
+
+test("project category controls update the rendered archive", async ({ page }, testInfo) => {
+  const pageErrors: string[] = []
+  const consoleErrors: string[] = []
+  page.on("pageerror", (error) => pageErrors.push(error.message))
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text())
+  })
+
+  await page.goto("/projects", { waitUntil: "domcontentloaded" })
+  await expect(page.getByRole("heading", { level: 1, name: "Project Signal Index" })).toBeVisible()
+
+  const aiFilter = page
+    .getByLabel("Project categories")
+    .getByRole("button", { name: /^AI\b/ })
+  await aiFilter.click()
+
+  await expect(aiFilter).toHaveAttribute("aria-pressed", "true")
+  await expect(page.getByRole("heading", { level: 3, name: "Astrocade AI QA Calibration Tool" })).toBeVisible()
+  await settleVisuals(page)
+  expect(pageErrors, "the project filter should not raise browser runtime errors").toEqual([])
+  expect(consoleErrors, "the project filter should not log browser console errors").toEqual([])
+
+  const screenshotPath = testInfo.outputPath("projects-ai-filter.png")
+  await page.screenshot({ path: screenshotPath, fullPage: true, animations: "disabled" })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },
+  testPathIgnorePatterns: ['/node_modules/', '/e2e/'],
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "type-check": "tsc --noEmit",
     "test": "pnpm type-check && jest",
     "test:unit": "jest",
-    "test:type": "tsc --noEmit"
+    "test:type": "tsc --noEmit",
+    "test:visual-smoke": "playwright test --config=playwright.config.ts"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "7.2.0",
@@ -40,6 +41,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@types/jest": "^29.5.14",
     "@types/node": "^22",
     "@types/react": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig, devices } from "@playwright/test"
+
+const port = 3100
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${port}`
+
+export default defineConfig({
+  testDir: "./e2e",
+  outputDir: "test-results/playwright",
+  preserveOutput: "always",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: 2,
+  reporter: "line",
+  use: {
+    baseURL,
+    colorScheme: "dark",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "desktop-chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1440, height: 1000 },
+      },
+    },
+    {
+      name: "mobile-chromium",
+      use: {
+        ...devices["iPhone 13"],
+        browserName: "chromium",
+        deviceScaleFactor: 1,
+        viewport: { width: 390, height: 844 },
+      },
+    },
+  ],
+  webServer: process.env.PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+        command: `pnpm dev --hostname 127.0.0.1 --port ${port}`,
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 9.5.0(@types/react@19.0.0)(expo-asset@11.1.5(expo@53.0.11(@babel/core@7.27.4)(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(expo-file-system@18.1.10(expo@53.0.11(@babel/core@7.27.4)(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0)))(expo-gl@15.1.6(expo@53.0.11(@babel/core@7.27.4)(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(expo@53.0.11(@babel/core@7.27.4)(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react-native@0.80.0(@babel/core@7.27.4)(@types/react@19.0.0)(react@19.0.0))(react@19.0.0)(three@0.182.0)
       '@vercel/analytics':
         specifier: 1.6.1
-        version: 1.6.1(@remix-run/react@2.16.8(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.0.2))(@sveltejs/kit@2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.5)(vite@6.3.5(@types/node@22.0.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.0)(yaml@2.8.0)))(svelte@5.34.5)(vite@6.3.5(@types/node@22.0.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.0)(yaml@2.8.0)))(next@15.2.8(@babel/core@7.27.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.34.5)(vue-router@4.5.1(vue@3.5.16(typescript@5.0.2)))(vue@3.5.16(typescript@5.0.2))
+        version: 1.6.1(@remix-run/react@2.16.8(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.0.2))(@sveltejs/kit@2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.5)(vite@6.3.5(@types/node@22.0.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.0)(yaml@2.8.0)))(svelte@5.34.5)(vite@6.3.5(@types/node@22.0.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.0)(yaml@2.8.0)))(next@15.2.8(@babel/core@7.27.4)(@playwright/test@1.61.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.34.5)(vue-router@4.5.1(vue@3.5.16(typescript@5.0.2)))(vue@3.5.16(typescript@5.0.2))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -49,7 +49,7 @@ importers:
         version: 0.454.0(react@19.0.0)
       next:
         specifier: 15.2.8
-        version: 15.2.8(@babel/core@7.27.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 15.2.8(@babel/core@7.27.4)(@playwright/test@1.61.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       openai:
         specifier: ^6.46.0
         version: 6.46.0(ws@8.18.2)(zod@3.25.76)
@@ -78,6 +78,9 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -1262,6 +1265,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -3167,6 +3175,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4366,6 +4379,16 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -7015,6 +7038,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
   '@polka/url@1.0.0-next.29':
     optional: true
 
@@ -7842,11 +7869,11 @@ snapshots:
       wonka: 6.3.5
     optional: true
 
-  '@vercel/analytics@1.6.1(@remix-run/react@2.16.8(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.0.2))(@sveltejs/kit@2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.5)(vite@6.3.5(@types/node@22.0.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.0)(yaml@2.8.0)))(svelte@5.34.5)(vite@6.3.5(@types/node@22.0.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.0)(yaml@2.8.0)))(next@15.2.8(@babel/core@7.27.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.34.5)(vue-router@4.5.1(vue@3.5.16(typescript@5.0.2)))(vue@3.5.16(typescript@5.0.2))':
+  '@vercel/analytics@1.6.1(@remix-run/react@2.16.8(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.0.2))(@sveltejs/kit@2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.5)(vite@6.3.5(@types/node@22.0.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.0)(yaml@2.8.0)))(svelte@5.34.5)(vite@6.3.5(@types/node@22.0.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.0)(yaml@2.8.0)))(next@15.2.8(@babel/core@7.27.4)(@playwright/test@1.61.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.34.5)(vue-router@4.5.1(vue@3.5.16(typescript@5.0.2)))(vue@3.5.16(typescript@5.0.2))':
     optionalDependencies:
       '@remix-run/react': 2.16.8(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.0.2)
       '@sveltejs/kit': 2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.5)(vite@6.3.5(@types/node@22.0.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.0)(yaml@2.8.0)))(svelte@5.34.5)(vite@6.3.5(@types/node@22.0.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.43.0)(yaml@2.8.0))
-      next: 15.2.8(@babel/core@7.27.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.2.8(@babel/core@7.27.4)(@playwright/test@1.61.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       svelte: 5.34.5
       vue: 3.5.16(typescript@5.0.2)
@@ -9343,6 +9370,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -10621,7 +10651,7 @@ snapshots:
   nested-error-stacks@2.0.1:
     optional: true
 
-  next@15.2.8(@babel/core@7.27.4)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  next@15.2.8(@babel/core@7.27.4)(@playwright/test@1.61.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@next/env': 15.2.8
       '@swc/counter': 0.1.3
@@ -10641,6 +10671,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.2.5
       '@next/swc-win32-arm64-msvc': 15.2.5
       '@next/swc-win32-x64-msvc': 15.2.5
+      '@playwright/test': 1.61.1
       sharp: 0.33.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -10871,6 +10902,14 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- add Playwright smoke coverage for the homepage, project index, Astrocade, Wizzo, and SpeakEasy at desktop and 390px mobile viewports
- verify successful responses, semantic page identity, framework overlays, page/console runtime health, and the live AI project-filter interaction
- upload representative full-page screenshots as a 14-day CI artifact without introducing brittle pixel baselines
- document the local workflow and close the completed future-backlog item

## Validation
- `pnpm test` (158 tests)
- `pnpm test:visual-smoke` (12 browser tests)
- `pnpm check:links`
- `pnpm build`
- `pnpm lint`

## Reviewer note
The new `visual-smoke` CI job installs Chromium independently and uploads `portfolio-visual-smoke` even when the job fails, so screenshots and retained traces are available for diagnosis.
