### PR TITLE
Rename X Games portfolio proof to Playfold

### DIFF
--- a/__tests__/dossier-exit-path.test.ts
+++ b/__tests__/dossier-exit-path.test.ts
@@ -21,7 +21,7 @@ describe("evidence dossier exit path", () => {
     }
   )
 
-  it("routes X Games through reviewed game and creator-system evidence", () => {
+  it("routes Playfold through reviewed game and creator-system evidence", () => {
     const exitPath = getDossierExitPath("x-games")
 
     expect(exitPath.capabilities).toEqual(

--- a/__tests__/x-games-case-study.test.ts
+++ b/__tests__/x-games-case-study.test.ts
@@ -9,14 +9,17 @@ interface DetailItem {
 }
 
 interface XGamesProject {
+  demo?: string
   gallery?: string[]
   image: string
   title: string
   details: {
     actions: DetailItem[]
+    client?: string
     proofRole?: string
     results: DetailItem[]
     services?: string[]
+    situation?: DetailItem[]
   }
 }
 
@@ -24,7 +27,17 @@ const projects = JSON.parse(
   fs.readFileSync(path.join(__dirname, "..", "public", "data", "projects.json"), "utf8"),
 ) as Record<string, XGamesProject>
 
-describe("X Games evidence dossier", () => {
+describe("Playfold evidence dossier", () => {
+  it("uses the current public product identity while preserving the stable route ID", () => {
+    const project = projects["x-games"]
+
+    expect(project.title).toBe("Playfold")
+    expect(project.demo).toBe("https://playfold.wizzolabs.net/")
+    expect(project.details.client).toBe("Playfold")
+    expect(project.details.situation?.[0]?.description).toContain("Playfold is")
+    expect(JSON.stringify(project)).not.toContain('"X Games"')
+  })
+
   it("states direct product-system proof instead of portfolio-value fallback copy", () => {
     const project = projects["x-games"]
     expect(project).toBeDefined()
@@ -62,11 +75,11 @@ describe("X Games evidence dossier", () => {
     })
 
     expect(media.map((item) => item.label)).toEqual([
-      "Live game discovery platform",
       "Generated-game control surface",
+      "Live game discovery platform",
       "Ranked game ecosystem",
     ])
-    expect(media.map((item) => item.section)).toEqual(["situation", "action", "result"])
+    expect(media.map((item) => item.section)).toEqual(["action", "situation", "result"])
     expect(media.every((item) => item.caption.length > 60)).toBe(true)
   })
 })

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -57,7 +57,7 @@ const proofPoints = [
   },
   {
     caseFile: "AF-02",
-    title: "X Games",
+    title: "Playfold",
     label: "Game UX / Creator systems",
     description:
       "Built an AI-assisted concept-to-play system connecting creator input, generated browser games, discovery, rankings, and direct play.",

--- a/app/projects/[id]/projectMedia.ts
+++ b/app/projects/[id]/projectMedia.ts
@@ -243,17 +243,17 @@ const PROJECT_MEDIA_COPY: Record<string, Record<string, ProjectMediaCopy>> = {
   "x-games": {
     "/projects/x-games/platform-home.png": {
       label: "Live game discovery platform",
-      caption: "Production discovery surface connecting the post-to-game promise to a live catalog of generated games, creator attribution, genres, play actions, and engagement signals.",
+      caption: "Historical shipped product surface captured before the Playfold naming transition, connecting the post-to-game promise to a live catalog of generated games, creator attribution, genres, play actions, and engagement signals.",
       section: "situation",
     },
     "/projects/x-games/generated-game-detail.png": {
       label: "Generated-game control surface",
-      caption: "A source post, generated game, tuning controls, play statistics, library action, and reporting path stay connected in one reviewable product surface.",
+      caption: "Historical shipped product state captured before the Playfold naming transition; a source post, generated game, tuning controls, play statistics, library action, and reporting path stay connected in one reviewable surface.",
       section: "action",
     },
     "/projects/x-games/leaderboard.png": {
       label: "Ranked game ecosystem",
-      caption: "The all-time leaderboard turns generated games into persistent social objects with ranked discovery, play counts, creator identity, and direct replay paths.",
+      caption: "Historical shipped product state captured before the Playfold naming transition; the all-time leaderboard turns generated games into persistent social objects with ranked discovery, play counts, creator identity, and direct replay paths.",
       section: "result",
     },
   },

--- a/design-qa-about.md
+++ b/design-qa-about.md
@@ -21,7 +21,7 @@ The production About page delayed all substantive content behind an animated ter
 - A real Adobe Experiential Horizons presentation image replaces the decorative terminal as the primary human signal.
 - The profile ledger uses repository-derived project and dossier counts.
 - The operating loop converts long-form positioning into four scan-friendly stages: Frame, Build, Measure, and Calibrate.
-- Wizzo, X Games, SpeakEasy, and professional-experience summaries create a direct path from positioning to verifiable proof.
+- Wizzo, Playfold, SpeakEasy, and professional-experience summaries create a direct path from positioning to verifiable proof.
 - Existing event assets provide truthful public-practice evidence instead of decorative imagery.
 - Contact and resume actions remain visible without adding a separate landing or recruiter page.
 

--- a/design-qa-playfold.md
+++ b/design-qa-playfold.md
@@ -1,4 +1,4 @@
-# X Games Evidence Dossier Design QA
+# Playfold Evidence Dossier Design QA
 
 ## Reference
 
@@ -14,21 +14,22 @@
 
 ## Product Intent
 
-This slice applies the shared evidence-dossier system to X Games. The page now presents the project as an operating AI-native game platform: source posts become playable games, generated behavior remains tunable, and the resulting catalog supports discovery, replay, reporting, and ranked competition.
+This slice applies the shared evidence-dossier system to Playfold. The page now presents the project as an operating AI-native game platform: source posts become playable games, generated behavior remains tunable, and the resulting catalog supports discovery, replay, reporting, and ranked competition.
 
 ## Implementation Review
 
-- X Games uses the shared dossier structure established across the public project archive.
+- Playfold uses the shared dossier structure established across the public project archive.
+- Existing interface captures remain historical shipped evidence from before the Playfold naming transition; they are labeled rather than cosmetically altered.
 - Case-file metadata identifies the product loop as Post / Generate / Play / Rank.
-- The public project record uses a reviewed live discovery image as its primary artifact.
+- The public project record uses the generated-game control surface as its primary artifact so the former brand is not foregrounded in archive cards.
 - Three live product states document discovery, the generated-game control surface, and the leaderboard.
 - Situation, Mandate, Build, and Outcomes copy is limited to behavior verified in the live product and repository data.
 - Projects outside the dossier configuration continue to use the existing case-study template.
 
 ## Visual Review
 
-- The X Games name and operating proof lead the first viewport without changing the site-wide terminal system.
-- The primary artifact shows the full live discovery context rather than a generic project thumbnail.
+- The Playfold name and operating proof lead the first viewport without changing the site-wide terminal system.
+- The primary artifact shows a real generated-game control state rather than a generic project thumbnail.
 - Supporting artifacts are legible in the desktop viewer and open through the existing fullscreen image interaction.
 - Evidence strips place each live product state next to the case-study claim it supports.
 - The mobile layout has one H1, no horizontal overflow, and clean stacking across the hero ledger, media viewer, case index, and evidence sections.
@@ -44,8 +45,10 @@ This slice applies the shared evidence-dossier system to X Games. The page now p
 
 ## Validation
 
-- `pnpm test`: 79 tests passed
+- `pnpm test:unit --runInBand`: 169 tests passed
+- `pnpm test:visual-smoke`: 34 desktop/mobile checks passed
 - `pnpm lint`: passed
+- `pnpm type-check`: passed
 - `pnpm check:links`: passed
 - `pnpm build`: passed
 

--- a/design-qa-release-acceptance.md
+++ b/design-qa-release-acceptance.md
@@ -15,7 +15,7 @@ This acceptance baseline covers the public project curation, professional-experi
 
 ## Accepted Behavior
 
-- Homepage featured proof is Wizzo, X Games, and SpeakEasy.
+- Homepage featured proof is Wizzo, Playfold, and SpeakEasy.
 - The public archive contains eleven explicitly curated public projects.
 - Games & Interactive is a virtual project category and does not alter the project category type.
 - Human-in-the-loop roles can surface high-level confidential employment evidence without internal artifacts.

--- a/docs/backlog/ACTIVE_BACKLOG.md
+++ b/docs/backlog/ACTIVE_BACKLOG.md
@@ -27,7 +27,7 @@ Rules:
 - The default public experience should remain trustworthy for hiring managers, clients, and partners.
 - The opt-in Metaverse path can carry the more theatrical Snow Crash and immersive references.
 - Homepage, About, and featured projects now center on AI-native product systems, game and creator
-  systems, and inspectable proof from Wizzo, X Games, SpeakEasy, and related public work.
+  systems, and inspectable proof from Wizzo, Playfold, SpeakEasy, and related public work.
 - Wizzo is supporting product proof, not the primary identity.
 - All 11 public projects use the shared evidence-dossier presentation, reviewed project media,
   global route context, evidence-driven exit paths, and calibrated archive thumbnails.

--- a/docs/backlog/FUTURE_BACKLOG.md
+++ b/docs/backlog/FUTURE_BACKLOG.md
@@ -18,7 +18,8 @@ If another doc, review, critique, or conversation records a follow-up, it must a
 ## Project Proof Parking Lot
 
 - [ ] Add a concise Wizzo product-system diagram if it clarifies chat, memory, tools, connectors, and quest loops.
-- [ ] Add X Games gameplay clips or generated-run evidence if it improves the case study beyond static screenshots.
+- [ ] Add Playfold gameplay clips or generated-run evidence if it improves the case study beyond static screenshots.
+- [ ] Replace pre-rename Playfold captures only after the canonical deployment exposes current, reviewable product states.
 - [ ] Add Vulnerability Visualizer workflow screenshots that show security triage from overview to remediation.
 - [ ] Add Creative Supply Engine deck excerpts or output comparisons if they reinforce AI creative operations.
 - [ ] Add Material Explorer AI-adjacent framing only if it becomes technically true, not as keyword stuffing.
@@ -33,7 +34,7 @@ If another doc, review, critique, or conversation records a follow-up, it must a
 - [ ] Build recruiter-focused and client-focused variants only if the single homepage starts feeling overloaded.
 - [ ] Add downloadable one-page project briefs for the top AI/product-system case studies.
 - [ ] Add a concise case-study index for hiring managers who want to scan proof quickly.
-- [ ] Add project-specific Open Graph cards for Wizzo, X Games, Creative Supply Engine, and Vulnerability Visualizer.
+- [ ] Add project-specific Open Graph cards for Wizzo, Playfold, Creative Supply Engine, and Vulnerability Visualizer.
 - [ ] Add structured data for portfolio projects if search snippets or link previews justify the work.
 
 ## Content And Case Study Depth
@@ -62,7 +63,7 @@ If another doc, review, critique, or conversation records a follow-up, it must a
 
 ### Tier 2: AI-Native Product Systems
 
-- Wizzo and X Games are the strongest public AI/product-system proof points.
+- Wizzo and Playfold are the strongest public AI/product-system proof points.
 - Professional experience supports relevant role matching without being presented as public projects.
 - Creative Supply Engine, Vulnerability Visualizer, SpeakEasy, and immersive work support range and depth.
 - AI language should describe real system behavior, not trend-chasing.

--- a/e2e/route-visual-smoke.spec.ts
+++ b/e2e/route-visual-smoke.spec.ts
@@ -10,6 +10,7 @@ const routes: SmokeRoute[] = [
   { name: "home", path: "/", heading: /^Mike_\s*Chaves_$/i },
   { name: "projects", path: "/projects", heading: "Project Signal Index" },
   { name: "wizzo", path: "/projects/wizzo", heading: "Wizzo" },
+  { name: "playfold", path: "/projects/x-games", heading: "Playfold" },
   { name: "geovoice", path: "/projects/geovoice", heading: "GeoVoice" },
   { name: "speakeasy", path: "/projects/speakeasy", heading: "SpeakEasy" },
 ]
@@ -116,7 +117,7 @@ test("homepage features only the curated public proof", async ({ page }) => {
 
   await expect(featured.getByRole("heading", { level: 3 })).toHaveText([
     "Wizzo",
-    "X Games",
+    "Playfold",
     "SpeakEasy",
   ])
   await expect(featured).not.toContainText(/Astrocade|Ford|Starbucks|Snorkel AI/u)
@@ -131,7 +132,7 @@ test("public archive follows the canonical project order", async ({ page }) => {
 
   await expect(archive.getByRole("heading", { level: 3 })).toHaveText([
     "Wizzo",
-    "X Games",
+    "Playfold",
     "SpeakEasy",
     "Sound Escape VR",
     "Material Explorer",
@@ -155,7 +156,7 @@ test("Games & Interactive exposes only the curated game set", async ({ page }) =
   await expect(gamesFilter).toHaveAttribute("aria-pressed", "true")
   const seeMore = page.getByRole("button", { name: "See More" })
   if (await seeMore.isVisible()) await seeMore.click()
-  await expect(page.getByRole("heading", { level: 3, name: "X Games" })).toBeVisible()
+  await expect(page.getByRole("heading", { level: 3, name: "Playfold" })).toBeVisible()
   await expect(page.getByRole("heading", { level: 3, name: "Sound Escape VR" })).toBeVisible()
   await expect(page.getByRole("heading", { level: 3, name: "Portals" })).toBeVisible()
   await expect(page.getByRole("heading", { level: 3, name: "Die, AI!" })).toBeVisible()
@@ -211,7 +212,7 @@ test("game and creator lens keeps public game proof central", async ({ page }) =
   await openPreset(page, "game-ux-creator-systems")
   const primaryProof = page.getByRole("heading", { level: 3, name: "Primary proof" }).locator("..")
 
-  await expect(primaryProof.getByText("X Games", { exact: true }).first()).toBeVisible()
+  await expect(primaryProof.getByText("Playfold", { exact: true }).first()).toBeVisible()
   await expect(page.getByText("Sound Escape VR", { exact: true }).first()).toBeVisible()
   await expect(page.getByText("Material Explorer", { exact: true }).first()).toBeVisible()
   await expect(page.getByText("Astrocade", { exact: true }).first()).toBeVisible()

--- a/public/data/projects.json
+++ b/public/data/projects.json
@@ -106,10 +106,10 @@
     }
   },
   "x-games": {
-    "title": "X Games",
+    "title": "Playfold",
     "category": "web",
     "description": "Built and operate an AI-first social game platform that turns X posts into playable browser games, then supports discovery, tuning, replay, sharing, reporting, and ranked competition around the generated catalog.",
-    "image": "/projects/x-games/platform-home.png",
+    "image": "/projects/x-games/generated-game-detail.png",
     "technologies": [
       "AI Game Generation",
       "Grok",
@@ -119,13 +119,13 @@
       "Leaderboards"
     ],
     "github": "",
-    "demo": "https://x-games-six.vercel.app/",
+    "demo": "https://playfold.wizzolabs.net/",
     "gallery": [
-      "/projects/x-games/generated-game-detail.png",
+      "/projects/x-games/platform-home.png",
       "/projects/x-games/leaderboard.png"
     ],
     "details": {
-      "client": "X Games",
+      "client": "Playfold",
       "date": "2026",
       "category": "AI Game Platform",
       "proofRole": "Direct product proof for AI-native generation, social distribution, game tuning, and ranked play in a live browser platform.",
@@ -138,7 +138,7 @@
       "situation": [
         {
           "title": "From Post to Playable System",
-          "description": "X Games is a live AI-native product loop: start from a post on X, generate a playable browser game with Grok, then make that game discoverable, replayable, tunable, shareable, and rankable."
+          "description": "Playfold is a live AI-native product loop: start from a post on X, generate a playable browser game with Grok, then make that game discoverable, replayable, tunable, shareable, and rankable."
         },
         {
           "title": "Product Challenge",


### PR DESCRIPTION
## Summary
- rename the public portfolio title and supporting copy from X Games to Playfold
- point the live-demo action at the canonical Playfold origin while preserving `/projects/x-games` and the `x-games` entity ID
- use the generated-game control surface as the featured artifact and label retained screenshots as pre-rename shipped evidence
- update About, Adaptive Focus display assertions, browser coverage, QA records, and backlog language

## Validation
- `pnpm lint`
- `pnpm type-check`
- `pnpm test:unit --runInBand` (169 passed)
- `pnpm check:links`
- `pnpm build`
- `pnpm test:visual-smoke` (34 desktop/mobile checks passed)

## Review note
The canonical `https://playfold.wizzolabs.net/` origin resolves successfully, but its current deployed HTML still shows the former brand. Portfolio screenshots are therefore retained as authentic pre-rename evidence and labeled accordingly. Replace them only after the canonical product deployment exposes reviewable Playfold-branded states.